### PR TITLE
Make the router work again

### DIFF
--- a/lib/router.php
+++ b/lib/router.php
@@ -89,7 +89,7 @@ class Router {
       'ajax'      => false,
       'filter'    => null,
       'method'    => 'GET',
-      'arguments' => null,
+      'arguments' => array(),
     );
 
     $route = new Obj(array_merge($defaults, $params, $optional));
@@ -162,7 +162,7 @@ class Router {
    * @return Route
    */
   public function run($path = null) {
-
+    $path   = is_null($path) ? url::path() : path::create($path)->toString();
     $method = r::method();
     $ajax   = r::ajax();
     $https  = r::ssl();


### PR DESCRIPTION
This commit fixes two bugs in the `Router` class:
- When calling the route using `call_user_func_array()` in the code, a `null` won't work here.
- The path to the current route is never set. Reversing line 165 back to a working version fixes it.

One additional question: I just upgraded from an old beta and could not call the route directly as you removed the `Router\Route` class. Using `call_user_func_array()` myself works fine, but why did you remove it?
