### PR TITLE
Router: Add custom arguments to RegEx matches

### DIFF
--- a/lib/router.php
+++ b/lib/router.php
@@ -165,7 +165,7 @@ class Router {
 
     // default path if nothing is set
     if(is_null($path)) {
-      return implode('/', (array)url::fragments(detect::path()));
+      $path = implode('/', (array)url::fragments(detect::path()));
     }
 
     // empty urls should never happen


### PR DESCRIPTION
If the user wants to define some of the arguments in the URL and some manually, this change makes that work.
