### PR TITLE
fix(str::slug): use custom separator if provided

### DIFF
--- a/lib/str.php
+++ b/lib/str.php
@@ -440,14 +440,14 @@ class Str {
     $string = static::lower($string);
     $string = static::ascii($string);
 
-    // replace spaces with simple dashes
-    $string = preg_replace('![^a-z0-9]!i','-', $string);
+    // replace spaces with URL-safe separator
+    $string = preg_replace('![^a-z0-9]!i', $separator, $string);
     // remove double dashes
     $string = preg_replace('![-]{2,}!','-', $string);
     // trim trailing and leading dashes
     $string = trim($string, '-');
-    // replace slashes with dashes
-    $string = str_replace('/', '-', $string);
+    // replace slashes with URL-safe separator
+    $string = str_replace('/', $separator, $string);
 
     return $string;
 


### PR DESCRIPTION
Just a little thing I stumbled upon yesterday: The str::slug method had already excepted a second argument for providing a custom separator for slug generation but it was not used in the end. This change enables using a custom replacement for the default dash.
