### PR TITLE
Thumb: use Media object in Thumb::destination

### DIFF
--- a/lib/media.php
+++ b/lib/media.php
@@ -42,10 +42,10 @@ class Media {
    */
   public function __construct($root, $url = null) {
     $this->url       = $url;
-    $this->root      = realpath($root);
     $this->filename  = basename($root);
     $this->name      = pathinfo($root, PATHINFO_FILENAME);
     $this->extension = strtolower(pathinfo($root, PATHINFO_EXTENSION));
+    $this->root      = realpath($root) ? realpath($root) : realpath(pathinfo($root, PATHINFO_DIRNAME)) . DS . pathinfo($root, PATHINFO_BASENAME) ;
   }
 
   /**

--- a/lib/thumb.php
+++ b/lib/thumb.php
@@ -60,7 +60,7 @@ class Thumb extends Obj {
       'hash'         => md5($this->source->root() . $this->settingsIdentifier()),
     ));
 
-    $this->destination = new Media($this->options['root'] . DS . $filename), $this->options['url'] . '/' . $filename);
+    $this->destination = new Media($this->options['root'] . DS . $filename, $this->options['url'] . '/' . $filename);
 
     // don't create the thumbnail if it's not necessary
     if($this->isObsolete()) return;
@@ -272,7 +272,7 @@ thumb::$drivers['im'] = function($thumb) {
     $command[] = '-blur 0x8';
   }
 
-  $command[] = '"' . $thumb->destination->root . '"';
+  $command[] = '"' . $thumb->destination->root() . '"';
 
   exec(implode(' ', $command));
 
@@ -285,7 +285,7 @@ thumb::$drivers['im'] = function($thumb) {
 thumb::$drivers['gd'] = function($thumb) {
 
   try {
-    $img = new abeautifulsite\SimpleImage($thumb->root());
+    $img = new abeautifulsite\SimpleImage($thumb->source->root());
     $img->quality = $thumb->options['quality'];
 
     if($thumb->options['crop']) {
@@ -304,7 +304,7 @@ thumb::$drivers['gd'] = function($thumb) {
       $img->blur('gaussian', 10);
     }
 
-    @$img->save($thumb->destination->root);
+    @$img->save($thumb->destination->root());
   } catch(Exception $e) {
     $thumb->error = $e;
   }

--- a/lib/thumb.php
+++ b/lib/thumb.php
@@ -49,8 +49,7 @@ class Thumb extends Obj {
     $this->source  = $this->result = is_a($source, 'Media') ? $source : new Media($source);
     $this->options = array_merge(static::$defaults, $this->params($params));
 
-    $this->destination = new Obj();
-    $this->destination->filename = str::template($this->options['filename'], array(
+    $filename = str::template($this->options['filename'], array(
       'extension'    => $this->source->extension(),
       'name'         => $this->source->name(),
       'filename'     => $this->source->filename(),
@@ -61,8 +60,7 @@ class Thumb extends Obj {
       'hash'         => md5($this->source->root() . $this->settingsIdentifier()),
     ));
 
-    $this->destination->url  = $this->options['url'] . '/' . $this->destination->filename;
-    $this->destination->root = $this->options['root'] . DS . $this->destination->filename;
+    $this->destination = new Media($this->options['root'] . DS . $filename), $this->options['url'] . '/' . $filename);
 
     // don't create the thumbnail if it's not necessary
     if($this->isObsolete()) return;
@@ -84,12 +82,12 @@ class Thumb extends Obj {
       $this->create();
 
       // check if creating the thumbnail failed
-      if(!file_exists($this->destination->root)) return;
+      if(!$this->destination->exists()) return;
 
     }
 
     // create the result object
-    $this->result = new Media($this->destination->root, $this->destination->url);
+    $this->result = $this->destination;
 
   }
 
@@ -162,7 +160,7 @@ class Thumb extends Obj {
 
     // if the thumb already exists and the source hasn't been updated
     // we don't need to generate a new thumbnail
-    if(file_exists($this->destination->root) and f::modified($this->destination->root) >= $this->source->modified()) return true;
+    if($this->destination->exists() and $this->destination->modified() >= $this->source->modified()) return true;
 
     return false;
 


### PR DESCRIPTION
Making `Thumb::destination` a `Media` object from the get go allows to extend the class more easily — by delegating the `exists` check to the `Thumb::destination` object instead of hard-writing it

(I'm trying to implement CloudFront CDN for images)