### PR TITLE
Fixed a bug in the email 'mail' service error handling.

### DIFF
--- a/lib/email.php
+++ b/lib/email.php
@@ -143,7 +143,7 @@ email::$services['mail'] = function($email) {
   ini_restore('sendmail_from');
 
   if(!$send) {
-    throw Exception('The email could not be sent');
+    throw new Error('The email could not be sent');
   }
 
 };


### PR DESCRIPTION
I believe I found a bug in the error handling of the `mail` e-mail service. There was a `new` keyword missing and an `Exception` thrown instead of an `Error`.
