### PR TITLE
collection::sortBy falls back to filename sorting

### DIFF
--- a/lib/collection.php
+++ b/lib/collection.php
@@ -308,15 +308,9 @@ class Collection extends I {
       $helper[$key] = str::lower($row->$field());
     }
 
-    // natural sorting
-    if($method === SORT_NATURAL) {
-      natsort($helper);
-      if($direction === SORT_DESC) $helper = array_reverse($helper);
-    } else if($direction === SORT_DESC) {
-      arsort($helper, $method);
-    } else {
-      asort($helper, $method);
-    }
+    // filter by field values and resort to sorting by filename 
+    // amongst equal values or if no values were found.
+    array_multisort(array_values($helper), $direction, $method, array_keys($helper), $direction, $method, $helper);
 
     // empty the collection data
     $collection->data = array();


### PR DESCRIPTION
Resort to sorting by filename amongst equal values or if no values were found.

This is especially useful when a blueprint specifies that files are sortable while they have no metadata (yet).

With this commit, sorting would then fall back to filename sorting whereas previously files would have ended up being sorted randomly.

As a desireable side effect, when two files have the same sorting value, they are sorted amongst themselves by filename, whereas previously they would have been sorted randomly.

(sidenote: I thought you had shared a solution somewhere for _actual_ multi-sorting, but can't remember where nor how. But that's another matter)
