### PR TITLE
Correct default value for referrer method.

### DIFF
--- a/lib/r.php
+++ b/lib/r.php
@@ -278,7 +278,7 @@ class R {
    * @param string $default Pass an optional URL to use as default referer if no referer is being found
    * @return string
    */
-  static public function referrer($default = nullg) {
+  static public function referrer($default = null) {
     return static::referer($default);
   }
 


### PR DESCRIPTION
The default value for the $default parameter of the referrer method was nullg. Should be null.
