### PR TITLE
Get original time that the image was taken.

### DIFF
--- a/lib/exif.php
+++ b/lib/exif.php
@@ -171,8 +171,8 @@ class Exif {
     if(!is_array($this->data)) return false;
 
     // store the timestamp when the picture has been taken
-    if(isset($this->data['DateTime'])) {
-      $this->timestamp = strtotime($this->data['DateTime']);
+    if(isset($this->data['DateTimeOriginal'])) {
+      $this->timestamp = strtotime($this->data['DateTimeOriginal']);
     } else {
       $this->timestamp = a::get($this->data, 'FileDateTime', $this->media->modified());
     }


### PR DESCRIPTION
Previously was fetching the modified timestamp of the image, not the original taken time.

The EXIF "DateTime" field stores the time the image was last modified (or copied) so it should essentially always be the same as the file modified date.

What I think it should be returning instead is the exact time the image was taken, which is stored in the "DateTimeOriginal" field in the EXIF data and falling back to the file modification time.
