### PR TITLE
Optional return value for route filter

### DIFF
--- a/lib/router.php
+++ b/lib/router.php
@@ -152,7 +152,7 @@ class Router {
   protected function filterer($filters) {
     foreach((array)$filters as $filter) {
       if(array_key_exists($filter, $this->filters) and is_callable($this->filters[$filter])) {
-        call_user_func($this->filters[$filter]);
+        return call_user_func($this->filters[$filter]);
       }
     }
   }
@@ -215,8 +215,7 @@ class Router {
 
     }
 
-    if($this->route) {
-      $this->filterer($this->route->filter);
+    if($this->route && ($this->filterer($this->route->filter) !== false)) {
       return $this->route;
     } else {
       return null;


### PR DESCRIPTION
Would be nice if the Router implementation would use a filters return value to determine whether the current route is valid or not. This way we could write our filters like this and only catch those cases where no route is returned:

``` php
/**
 * Capability Test
 *
 * @return  boolean
 */
$this->router->filter('canEdit', function() use ($user, $cap) {
  $roles   = str::split($cap['edit'], '|');
  return in_array('author', $roles) || ($user && call(array($user, 'hasRole'), $roles));
});
```
