### PR TITLE
Fix boolean HTML attributes

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -152,6 +152,7 @@ class Html {
     }
 
     if(empty($value) and $value !== '0') return false;
+    if(is_bool($value)) return ($value === true)? $name : '';
     return $name . '="' . $value . '"';
   }
 


### PR DESCRIPTION
Fixes getkirby/kirby#134 by returning the name of the attribute without the integer value when the value is a boolean.
