### PR TITLE
Add null to list of SQL literals

### DIFF
--- a/lib/sql.php
+++ b/lib/sql.php
@@ -203,8 +203,8 @@ class Sql {
 
       foreach($values AS $key => $value) {
         $fields[] = $key;
-        if(in_array($value, $this->literals)) {
-          $output[] = $value;
+        if(in_array($value, $this->literals, true)) {
+          $output[] = ($value === null)? 'null' : $value;
         } elseif(is_array($value)) {
           $output[] = "'" . $this->db->escape(json_encode($value)) . "'";
         } else {

--- a/lib/sql.php
+++ b/lib/sql.php
@@ -14,7 +14,7 @@
 class Sql {
 
   // list of literals which should not be escaped in queries
-  protected $literals = array('NOW()');
+  protected $literals = array('NOW()', null);
 
   // the parent db connection
   protected $db;
@@ -186,7 +186,7 @@ class Sql {
 
       foreach($values AS $key => $value) {
         if(in_array($value, $this->literals)) {
-          $output[] = $key . ' = ' . $value;
+          $output[] = $key . ' = ' . (($value === null)? 'null' : $value);
         } elseif(is_array($value)) {
           $output[] = $key . " = '" . json_encode($value) . "'";
         } else {

--- a/lib/sql.php
+++ b/lib/sql.php
@@ -185,7 +185,7 @@ class Sql {
       $output = array();
 
       foreach($values AS $key => $value) {
-        if(in_array($value, $this->literals)) {
+        if(in_array($value, $this->literals, true)) {
           $output[] = $key . ' = ' . (($value === null)? 'null' : $value);
         } elseif(is_array($value)) {
           $output[] = $key . " = '" . json_encode($value) . "'";


### PR DESCRIPTION
Trying to set a value to `null` before resulted in a string value of `''` (empty string) instead of an actual null value.
The string `'null'` is not affected by this change and will still result in a string value of `'null'` in the DB.