### PR TITLE
Fix Database::dropTable() method

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -366,7 +366,7 @@ class Database {
    * @param string $table
    * @return boolean
    */
-  static public function dropTable($table) {
+  public function dropTable($table) {
     $sql = new SQL($this);
     return $this->execute($sql->dropTable());
   }

--- a/lib/database.php
+++ b/lib/database.php
@@ -368,7 +368,7 @@ class Database {
    */
   public function dropTable($table) {
     $sql = new SQL($this);
-    return $this->execute($sql->dropTable());
+    return $this->execute($sql->dropTable($table));
   }
 
   /**


### PR DESCRIPTION
The proposed change fixes an issue with the database::dropTable() method was incorrectly declared as a static method.