### PR TITLE
add hasQuery function to check for query string

### DIFF
--- a/lib/url.php
+++ b/lib/url.php
@@ -33,6 +33,15 @@ class Url {
     return parse_url($url, PHP_URL_SCHEME);
 
   }
+  
+  /**
+   * Returns if the current url has a query string
+   * 
+   * @return boolean
+   */
+  static public function hasQuery($url) {
+    return (bool)strpos('?', $url);
+  }
 
   /**
    * Returns the current url with all bells and whistles


### PR DESCRIPTION
I'm not sure there is any scope for a URL to have a '?' if there is no query string, so I think this ought to be fine.