### PR TITLE
Fix HTTPS detection on nginx

### DIFF
--- a/lib/url.php
+++ b/lib/url.php
@@ -20,7 +20,7 @@ class Url {
   static public function scheme($url = null) {
     if(is_null($url)) {      
       if(
-        (isset($_SERVER['HTTPS']) and strtolower($_SERVER['HTTPS']) != 'off') or
+        (isset($_SERVER['HTTPS']) and !empty($_SERVER['HTTPS']) and strtolower($_SERVER['HTTPS']) != 'off') or
         server::get('SERVER_PORT')            == '443' or 
         server::get('HTTP_X_FORWARDED_PORT')  == '443' or 
         server::get('HTTP_X_FORWARDED_PROTO') == 'https'


### PR DESCRIPTION
This should fix the issue opened at https://github.com/getkirby/kirby/issues/184
You can see same bug report on another CMS here http://dev.cmsmadesimple.org/bug/view/9559

This is my $_SERVER array in nginx:
````
Array
(
    [USER] => vagrant
    [HOME] => /home/vagrant
    [FCGI_ROLE] => RESPONDER
    [QUERY_STRING] => 
    [REQUEST_METHOD] => GET
    [CONTENT_TYPE] => 
    [CONTENT_LENGTH] => 
    [SCRIPT_FILENAME] => /var/www/kirby/index.php
    [SCRIPT_NAME] => /index.php
    [REQUEST_URI] => /
    [DOCUMENT_URI] => /index.php
    [DOCUMENT_ROOT] => /var/www/kirby
    [SERVER_PROTOCOL] => HTTP/1.1
    [GATEWAY_INTERFACE] => CGI/1.1
    [SERVER_SOFTWARE] => nginx/1.1.19
    [REMOTE_ADDR] => 1.3.3.1
    [REMOTE_PORT] => 57181
    [SERVER_ADDR] => 1.3.3.7
    [SERVER_PORT] => 80
    [SERVER_NAME] => kirby.kal
    [HTTPS] => 
    [REDIRECT_STATUS] => 200
    [HTTP_HOST] => kirby.kal
    [HTTP_CONNECTION] => keep-alive
    [HTTP_PRAGMA] => no-cache
    [HTTP_CACHE_CONTROL] => no-cache
    [HTTP_ACCEPT] => text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
    [HTTP_USER_AGENT] => Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36
    [HTTP_DNT] => 1
    [HTTP_ACCEPT_ENCODING] => gzip, deflate, sdch
    [HTTP_ACCEPT_LANGUAGE] => en-US,en;q=0.8,es;q=0.6,fi;q=0.4
    [HTTP_COOKIE] => PHPSESSID=jk0g9l3fcdrjll3e48fne7ooa4
    [PHP_SELF] => /index.php
    [REQUEST_TIME] => 1422960387
)
````