### PR TITLE
required: not empty

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -310,7 +310,7 @@ function invalid($data, $rules, $messages = array()) {
     foreach($validations as $method => $options) {
       if(is_numeric($method)) $method = $options;
       if($method == 'required') {
-        if(!isset($data[$field])) $errors[$field] = a::get($messages, $field, $field);
+        if(!isset($data[$field]) || empty($data[$field])) $errors[$field] = a::get($messages, $field, $field);
       } else {
         if(!is_array($options)) $options = array($options);
         array_unshift($options, a::get($data, $field));


### PR DESCRIPTION
When validating a field that is required also check whether it’s empty.