### PR TITLE
Fix quote types of default values

### DIFF
--- a/lib/sql.php
+++ b/lib/sql.php
@@ -283,7 +283,7 @@ class Sql {
 
       $defaultValue = null;
       if(isset($column['default'])) {
-        $defaultValue = is_integer($column['default']) ? $column['default'] : '"' . $column['default'] . '"';
+        $defaultValue = is_integer($column['default']) ? $column['default'] : "'" . $column['default'] . "'";
       }
 
       $output[] = trim(str::template($template[$type], array(


### PR DESCRIPTION
Strings used as default value for table columns need to be wrapped in single quotes.

https://www.sqlite.org/datatype3.html