### PR TITLE
Use backticks for sql identifiers

### DIFF
--- a/lib/sql.php
+++ b/lib/sql.php
@@ -225,7 +225,7 @@ class Sql {
    * @return string
    */
   public function dropTable($table) {
-    return 'DROP TABLE "' . $table . '"';
+    return 'DROP TABLE `' . $table . '`';
   }
 
   /**


### PR DESCRIPTION
In order to increase compatibility it is advisable to use backticks as quote sql identifiers. While sqlite usually runs fine with double quotes MySQL requires ANSI_QUOTES mode to be enabled. In the createTable method you correctly replace double quotes with backticks. 

In the remaining methods (insert, select, update, delete) table identifiers are not quoted at all. These would break if users use any reserved characters in table or column names (e.g. the space character). Don't know why someone would do that, but maybe it would be a good idea to support these use cases...

(Sorry for fixing these issues 'bit by bit', but I just discovered them while debugging my own application)