### PR TITLE
Add extend and blocks feature, the only missed on tpl class.

### DIFF
--- a/lib/tpl.php
+++ b/lib/tpl.php
@@ -26,4 +26,102 @@ class Tpl extends Silo {
     echo $content;
   }
 
+  /**
+   * Block contents.
+   *
+   * @var array
+   */
+  static public $blocks = [];
+
+  /**
+   * Extend contents.
+   *
+   * @var array
+   */
+  static public $extends = [];
+  
+  /**
+   * Start block.
+   * 
+   * @param  String $name
+   * @return Null
+   */
+  public static function block_start($name) {
+
+    if (!isset(static::$blocks[$name])){
+      static::$blocks[$name] = [];
+    }
+
+    ob_start();
+  }
+
+  /**
+   * End block.
+   * 
+   * @param  String $name
+   * @return Null
+   */
+  public static function block_end($name)
+  {
+    $out = ob_get_clean();
+
+    if (isset(static::$blocks[$name])) {
+      static::$blocks[$name][] = $out;
+    }
+  }
+
+  /**
+   * Get block content.
+   * 
+   * @param  String $name
+   * @param  array  $options
+   * @return String
+   */
+  public static function block($name, $options = [])
+  {
+    if (!isset(static::$blocks[$name])) {
+      return null;
+    }
+
+    $options = array_merge([
+        'print' => true
+    ], $options);
+
+    $block = implode("\n", static::$blocks[$name]);
+
+    if ($options['print']) {
+      echo $block;
+    }
+
+    return $block;
+  }
+
+  /**
+   * Open extend block for include the main template.
+   * 
+   * @param $template
+   */
+  public static function extend_start($template)
+  {
+    $template_file = Kirby::instance()->roots()->templates() . DS . $template . '.php';
+
+    if (file_exists($template_file) and !isset(static::$extends[$template])) {
+      static::$extends[$template] = $template_file;
+    }
+  }
+
+  /**
+   * Close the extend block and print out.
+   *
+   * @param $template
+   * @return null
+   */
+  public static function extend_end($template)
+  {
+    if (isset(static::$extends[$template])) {
+      ob_start();
+      include static::$extends[$template];
+      echo ob_get_clean();
+    }
+  }
 }


### PR DESCRIPTION
It's really simple to use, you can use default.php template for the base template, and example for the home template you need to add only the content block, here the examples:

*default.php*

    <h1>Default template</h1>
    
    <?php Tpl::block('body_content') ?>

*home.php*

    <?php Tpl::extend_start('default') ?>
    
        <?php Tpl::block_start('body_content') ?>
            <h1><?php echo $page->title()->html() ?></h1>
        <?php Tpl::block_end('body_content') ?>
    
    <?php Tpl::extend_end('default') ?>

In this case the block "body_content" replaced from *home.php* template to *default.php* template.

Anyone have more fine idea for this? I hate all the times replace the default.php template with another one and porting some code from default template. It's true we can use the snippet, but for me it's really useless... best way is the block, i take this idea from twig (the best template engine i tried in this years), the extended it's really nice, we can use only one call but we need to add to the end of template, so with start/end it's more clear.