### PR TITLE
Add 307 code to supported HTTP codes

### DIFF
--- a/lib/header.php
+++ b/lib/header.php
@@ -23,6 +23,7 @@ class Header {
     '_302' => 'Found',
     '_303' => 'See Other',
     '_304' => 'Not Modified',
+    '_307' => 'Temporary Redirect',
     //...
     '_400' => 'Bad Request',
     '_401' => 'Unauthorized',


### PR DESCRIPTION
I needed this code to redirect a POST request (to serve a different language's content on the same URL).

Why this works: http://programmers.stackexchange.com/questions/99894/why-doesnt-http-have-post-redirect

If you have another way to load a different language's content within a template, I'd be interested in that as well.