### PR TITLE
Aggregate method default not working correctly.

### DIFF
--- a/lib/database/query.php
+++ b/lib/database/query.php
@@ -632,7 +632,7 @@ class Query {
 
     $fetch  = $this->fetch;
     $row    = $this->select($method . '(' . $column . ') as aggregation')->fetch('Obj')->first();
-    $result =  $row ? $row->get('aggregation', $default) : 0;
+    $result =  $row ? $row->get('aggregation') : $default;
     $this->fetch($fetch);
     return $result;
   }


### PR DESCRIPTION
When you try to count rows into undefined table (not exists) return int(0) in any case if i set $default with false.