### PR TITLE
Fix Url::build() method. Fix for #88.

### DIFF
--- a/lib/url.php
+++ b/lib/url.php
@@ -159,9 +159,8 @@ class Url {
     if(!empty($parts['fragments'])) $result[] = implode('/', $parts['fragments']);
     if(!empty($parts['params']))    $result[] = static::paramsToString($parts['params']);
     if(!empty($parts['query']))     $result[] = '?' . static::queryToString($parts['query']);
-    if(!empty($parts['hash']))      $result[] = '#' . $parts['hash'];
 
-    return implode('/', $result);
+    return implode('/', $result) . (!empty($parts['hash']) ? '#' . $parts['hash'] : '');
 
   }
 


### PR DESCRIPTION
Make the `Url::build()` method build correct urls when a hash is involved.

See #88 for extended description.