### PR TITLE
Allow '_' as a valid character for str::slug.

### DIFF
--- a/lib/str.php
+++ b/lib/str.php
@@ -452,7 +452,7 @@ class Str {
    * @param  string  $separator To be used instead of space and other non-word characters.
    * @return string  The safe string
    */
-  static public function slug($string, $separator = '-', $allowed = 'a-z0-9') {
+  static public function slug($string, $separator = '-', $allowed = '_a-z0-9') {
 
     $string = trim($string);
     $string = static::lower($string);


### PR DESCRIPTION
I'm currently having a discussion with [aftereffectsmagic](http://forum.getkirby.com/users/aftereffectsmagic/) on how to implement the [calendar plugin](https://github.com/mzur/kirby-calendar-plugin) using subpages as events instead of a structure field.

This works really well with one exception: The calendar plugin requires an event to have a `_begin_date` field (there can be others like `_begin_time`, too). The `_` prefix marks them as immutable fields of the plugin. The snake case format was chosen because [the panel converts all keys to lower case](https://github.com/getkirby/panel/issues/330).

While this works fine using a structure field containing all events, it breaks when each event should be represented by a subpage. This is because of the `str::slug` method [stripping all page field keys](https://github.com/getkirby/toolkit/blob/e5f49628324036240eb144ebea6859cca748767f/lib/data.php#L96) of any character other than `a-z0-9`, which includes the `_`.

Since strings containing `_` are valid PHP variable names (for page field accessors like `$page->_begin_date()`) as well as valid URLs, I'm now creating this pull request adding `_` to the allowed characters of `str:slug` to fix this issue.