### PR TITLE
Ascii foreign chars can set from options

### DIFF
--- a/lib/str.php
+++ b/lib/str.php
@@ -594,7 +594,7 @@ class Str {
    * @return string
    */
   static public function ascii($string) {
-    $foreign = static::$ascii;
+    $foreign =  c::get('ascii', static::$ascii);
     $string  = preg_replace(array_keys($foreign), array_values($foreign), $string);
     return preg_replace('/[^\x09\x0A\x0D\x20-\x7E]/', '', $string);
   }


### PR DESCRIPTION
In our language as turkish, some chars broken on url address. I just implement that ascii chars can set from options.

**Wrong convert:** Üsküdar > ueskuedar
**Right convert:** Üsküdar > uskudar

**Wrong convert:** Öğrenci > oegrenci
**Right convert:** Öğrenci > ogrenci

**Sample Usage**
````
c::set('ascii', array(
					'/Ä/' => 'Ae',
					'/æ|ǽ|ä/' => 'ae',
					'/œ|ö/' => 'oe',
					'/À|Á|Â|Ã|Å|Ǻ|Ā|Ă|Ą|Ǎ|А/' => 'A',
					'/à|á|â|ã|å|ǻ|ā|ă|ą|ǎ|ª|а/' => 'a',
					'/Б/' => 'B',
					'/б/' => 'b',
					'/Ç|Ć|Ĉ|Ċ|Č|Ц/' => 'C',
					'/ç|ć|ĉ|ċ|č|ц/' => 'c',
					'/Ð|Ď|Đ/' => 'Dj',
					'/ð|ď|đ/' => 'dj',
					'/Д/' => 'D',
					'/д/' => 'd',
					'/È|É|Ê|Ë|Ē|Ĕ|Ė|Ę|Ě|Е|Ё|Э/' => 'E',
					'/è|é|ê|ë|ē|ĕ|ė|ę|ě|е|ё|э/' => 'e',
					'/Ф/' => 'F',
					'/ƒ|ф/' => 'f',
					'/Ĝ|Ğ|Ġ|Ģ|Г/' => 'G',
					'/ĝ|ğ|ġ|ģ|г/' => 'g',
					'/Ĥ|Ħ|Х/' => 'H',
					'/ĥ|ħ|х/' => 'h',
					'/Ì|Í|Î|Ï|Ĩ|Ī|Ĭ|Ǐ|Į|İ|И/' => 'I',
					'/ì|í|î|ï|ĩ|ī|ĭ|ǐ|į|ı|и/' => 'i',
					'/Ĵ|Й/' => 'J',
					'/ĵ|й/' => 'j',
					'/Ķ|К/' => 'K',
					'/ķ|к/' => 'k',
					'/Ĺ|Ļ|Ľ|Ŀ|Ł|Л/' => 'L',
					'/ĺ|ļ|ľ|ŀ|ł|л/' => 'l',
					'/М/' => 'M',
					'/м/' => 'm',
					'/Ñ|Ń|Ņ|Ň|Н/' => 'N',
					'/ñ|ń|ņ|ň|ŉ|н/' => 'n',
					'/Ö/' => 'O',
					'/ö/' => 'o',
					'/Ò|Ó|Ô|Õ|Ō|Ŏ|Ǒ|Ő|Ơ|Ø|Ǿ|О/' => 'O',
					'/ò|ó|ô|õ|ō|ŏ|ǒ|ő|ơ|ø|ǿ|º|о/' => 'o',
					'/П/' => 'P',
					'/п/' => 'p',
					'/Ŕ|Ŗ|Ř|Р/' => 'R',
					'/ŕ|ŗ|ř|р/' => 'r',
					'/Ś|Ŝ|Ş|Ș|Š|С/' => 'S',
					'/ś|ŝ|ş|ș|š|ſ|с/' => 's',
					'/Ţ|Ț|Ť|Ŧ|Т/' => 'T',
					'/ţ|ț|ť|ŧ|т/' => 't',
					'/Ü/' => 'U',
					'/ü/' => 'u',
					'/Ù|Ú|Û|Ũ|Ū|Ŭ|Ů|Ű|Ų|Ư|Ǔ|Ǖ|Ǘ|Ǚ|Ǜ|У/' => 'U',
					'/ù|ú|û|ũ|ū|ŭ|ů|ű|ų|ư|ǔ|ǖ|ǘ|ǚ|ǜ|у/' => 'u',
					'/В/' => 'V',
					'/в/' => 'v',
					'/Ý|Ÿ|Ŷ|Ы/' => 'Y',
					'/ý|ÿ|ŷ|ы/' => 'y',
					'/Ŵ/' => 'W',
					'/ŵ/' => 'w',
					'/Ź|Ż|Ž|З/' => 'Z',
					'/ź|ż|ž|з/' => 'z',
					'/Æ|Ǽ/' => 'AE',
					'/ß/'=> 'ss',
					'/Ĳ/' => 'IJ',
					'/ĳ/' => 'ij',
					'/Œ/' => 'OE',
					'/Ч/' => 'Ch',
					'/ч/' => 'ch',
					'/Ю/' => 'Ju',
					'/ю/' => 'ju',
					'/Я/' => 'Ja',
					'/я/' => 'ja',
					'/Ш/' => 'Sh',
					'/ш/' => 'sh',
					'/Щ/' => 'Shch',
					'/щ/' => 'shch',
					'/Ж/' => 'Zh',
					'/ж/' => 'zh',
				  )
	);
````