### PR TITLE
XML Node Attributes Enhancement

### DIFF
--- a/lib/xml.php
+++ b/lib/xml.php
@@ -99,17 +99,32 @@ class Xml {
   static function create($array, $tag = 'root', $head = true, $charset = 'utf-8', $tab = '  ', $level = 0) {
     $result  = ($level == 0 and $head) ? '<?xml version="1.0" encoding="' . $charset . '"?>' . PHP_EOL : '';
     $nlevel  = ($level + 1);
-    $result .= str_repeat($tab, $level) . '<' . $tag . '>' . PHP_EOL;
+    $attr = '@attributes';
+    $attributes = html::attr(a::get($array, $attr));
+    if($tag == $attr || count($array) == 1 and $attributes) {
+      // return the self closed node
+      return str_repeat($tab, $level) . '<' . $tag . ($attributes ? ' ' . $attributes : '') . ' />' . PHP_EOL;
+    } else {
+      $result .= str_repeat($tab, $level) . '<' . $tag . ($attributes ? ' ' . $attributes . ' ' : '') . '>' . PHP_EOL;
+    }
     foreach($array as $key => $value) {
       $key = str::lower($key);
+      if($key == $attr) {
+        continue;
+      }
       if(is_array($value)) {
         $mtags = false;
         foreach($value as $key2 => $value2) {
+          if($key2 == $attr) {
+            continue;
+          }
           if(is_array($value2)) {
-            $result .= static::create($value2, $key, $head, $charset, $tab, $nlevel);
+            $result .= static::create($value2, $key2, $head, $charset, $tab, $nlevel);
+          } elseif(!is_numeric($key)) {
+            $result .= static::create($value, $key, $head, $charset, $tab, $nlevel);
           } elseif(trim($value2) != '') {
-            $value2  = (htmlspecialchars($value2) != $value2) ? '<![CDATA[' . $value2 . ']]>' : $value2;
-            $result .= str_repeat($tab, $nlevel) . '<' . $key . '>' . $value2 . '</' . $key . '>' . PHP_EOL;
+            $value2  = (!strstr($value2, '<![CDATA[') and htmlspecialchars($value2) != $value2) ? '<![CDATA[' . $value2 . ']]>' : $value2;
+            $result .= str_repeat($tab, $nlevel) . '<' . $key2 . '>' . $value2 . '</' . $key2 . '>' . PHP_EOL;
           }
           $mtags = true;
         }
@@ -117,7 +132,7 @@ class Xml {
           $result .= static::create($value, $key, $head, $charset, $tab, $nlevel);
         }
       } elseif(trim($value) != '') {
-        $value   = (htmlspecialchars($value) != $value) ? '<![CDATA[' . $value . ']]>' : $value;
+        $value   = (!strstr($value, '<![CDATA[') and htmlspecialchars($value) != $value) ? '<![CDATA[' . $value . ']]>' : $value;
         $result .= str_repeat($tab, $nlevel) . '<' . $key . '>' . $value . '</' . $key . '>' . PHP_EOL;
       }
     }

--- a/lib/xml.php
+++ b/lib/xml.php
@@ -101,7 +101,7 @@ class Xml {
     $nlevel  = ($level + 1);
     $attr = '@attributes';
     $attributes = html::attr(a::get($array, $attr));
-    if($tag == $attr || count($array) == 1 and $attributes) {
+    if(count($array) == 1 and $attributes) {
       // return the self closed node
       return str_repeat($tab, $level) . '<' . $tag . ($attributes ? ' ' . $attributes : '') . ' />' . PHP_EOL;
     } else {
@@ -133,7 +133,7 @@ class Xml {
         }
       } elseif(trim($value) != '') {
         $value   = (!strstr($value, '<![CDATA[') and htmlspecialchars($value) != $value) ? '<![CDATA[' . $value . ']]>' : $value;
-        $result .= str_repeat($tab, $nlevel) . '<' . $key . '>' . $value . '</' . $key . '>' . PHP_EOL;
+        $result .= str_repeat($tab, $nlevel) . (is_numeric($key) ? '' : '<' . $key . '>') . $value . (is_numeric($key) ? '' : '</' . $key . '>') . PHP_EOL;
       }
     }
     return $result . str_repeat($tab, $level) . '</' . $tag . '>' . PHP_EOL;


### PR DESCRIPTION
## Enhanced the way XML is generated from `xml::create()`

The array that is passed can now add attributes to the xml nodes through array key `@attributes`, which utilizes the `html::attr()` method. Additionally, the logic for CDATA wrappers in improved so that you don't double wrap content that already contains the CDATA wrapper. This enhancement will also render a self-closed node when child nodes are not present.
