### PR TITLE
Store safe name in variable

### DIFF
--- a/lib/thumb.php
+++ b/lib/thumb.php
@@ -94,13 +94,15 @@ class Thumb extends Obj {
     } else {
 
       $destination = new Obj();
+      
+      $safeName = f::safeName($this->source->name());
 
       $destination->filename = str::template($this->options['filename'], array(
         'extension'    => $this->source->extension(),
         'name'         => $this->source->name(),
         'filename'     => $this->source->filename(),
-        'safeName'     => f::safeName($this->source->name()),
-        'safeFilename' => f::safeName($this->source->name()) . '.' . $this->extension(),
+        'safeName'     => $safeName,
+        'safeFilename' => $safeName . '.' . $this->extension(),
         'width'        => $this->options['width'],
         'height'       => $this->options['height'],
         'hash'         => md5($this->source->root() . $this->settingsIdentifier()),


### PR DESCRIPTION
The `f::safeName()` method needs a lot of CPU time, so it should not be executed more times than necessary. On a page with dozens of thumbnails, a PHP profiler told me, that it was responsible for 30-50% of the total page generation time.

If the thumb class is also intended for generating `<picture>` tags with multiple sources of the same image, you should also consider to store every result of the function in a static variable to avoid double-execution of the function.