### PR TITLE
Thumbnail hash independent of site root

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,6 @@
     "forum": "http://forum.getkirby.com",
     "source": "https://github.com/getkirby/toolkit"
   },
-  "replace": {
-    "abeautifulsite/simpleimage": "2.5.3",
-    "mustangostang/spyc": "0.5.1"
-  },
   "autoload": {
     "files": ["bootstrap.php"]
   }

--- a/helpers.php
+++ b/helpers.php
@@ -65,8 +65,8 @@ function param($key = null, $default = null) {
  * Smart version of return with an if condition as first argument
  *
  * @param boolean $condition
- * @param string $value The string to be returned if the condition is true
- * @param string $alternative An alternative string which should be returned when the condition is false
+ * @param mixed $value The string to be returned if the condition is true
+ * @param mixed $alternative An alternative string which should be returned when the condition is false
  * @return null
  */
 function r($condition, $value, $alternative = null) {
@@ -77,8 +77,8 @@ function r($condition, $value, $alternative = null) {
  * Smart version of echo with an if condition as first argument
  *
  * @param boolean $condition
- * @param string $value The string to be echoed if the condition is true
- * @param string $alternative An alternative string which should be echoed when the condition is false
+ * @param mixed $value The string to be echoed if the condition is true
+ * @param mixed $alternative An alternative string which should be echoed when the condition is false
  */
 function e($condition, $value, $alternative = null) {
   echo r($condition, $value, $alternative);

--- a/helpers.php
+++ b/helpers.php
@@ -64,7 +64,7 @@ function param($key = null, $default = null) {
 /**
  * Smart version of return with an if condition as first argument
  *
- * @param boolean $condition
+ * @param mixed $condition
  * @param mixed $value The string to be returned if the condition is true
  * @param mixed $alternative An alternative string which should be returned when the condition is false
  * @return null
@@ -76,7 +76,7 @@ function r($condition, $value, $alternative = null) {
 /**
  * Smart version of echo with an if condition as first argument
  *
- * @param boolean $condition
+ * @param mixed $condition
  * @param mixed $value The string to be echoed if the condition is true
  * @param mixed $alternative An alternative string which should be echoed when the condition is false
  */

--- a/helpers.php
+++ b/helpers.php
@@ -109,7 +109,7 @@ function dump($variable, $echo = true) {
   } else {
     $output = '<pre>' . print_r($variable, true) . '</pre>';
   }
-  if($echo == true) echo $output;
+  if($echo === true) echo $output;
   return $output;
 }
 
@@ -327,10 +327,10 @@ function invalid($data, $rules, $messages = array()) {
     foreach($validations as $method => $options) {
       if(is_numeric($method)) $method = $options;
       if($method == 'required') {
-        if(!isset($data[$field]) or (empty($data[$field]) and $data[$field] !== 0)) {
+        if(!isset($data[$field]) || (empty($data[$field]) && $data[$field] !== 0)) {
           $errors[$field] = a::get($messages, $field, $field);
         }
-      } else if(!empty($data[$field]) or $data[$field] === 0) {
+      } else if(!empty($data[$field]) || $data[$field] === 0) {
         if(!is_array($options)) $options = array($options);
         array_unshift($options, a::get($data, $field));
         if(!call(array('v', $method), $options)) {

--- a/lib/a.php
+++ b/lib/a.php
@@ -436,7 +436,7 @@ class A {
    * @param   array    $array The array to analyze
    * @return  boolean  true: The array is associative false: It's not
    */
-  static function isAssociative($array) {
+  static public function isAssociative($array) {
     return !ctype_digit(implode(NULL, array_keys($array)));
   }
 
@@ -447,7 +447,7 @@ class A {
    * @param   int    $decimals The number of decimals to return
    * @return  int    The average value
    */
-  static function average($array, $decimals = 0) {
+  static public function average($array, $decimals = 0) {
     return round(array_sum($array), $decimals) / sizeof($array);
   }
 
@@ -458,10 +458,10 @@ class A {
    * @param array $array2
    * @return array
    */
-  static function merge($array1, $array2) {
+  static public function merge($array1, $array2) {
     $merged = $array1;
     foreach($array2 as $key => $value) {
-      if(is_array($value) and isset($merged[$key]) and is_array($merged[$key])) {
+      if(is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
         $merged[$key] = static::merge($merged[$key], $value);
       } else {
         $merged[$key] = $value;

--- a/lib/a.php
+++ b/lib/a.php
@@ -44,7 +44,7 @@ class A {
    * @param   mixed  $default Optional default value, which should be returned if no element has been found
    * @return  mixed
    */
-  static public function get($array, $key, $default = null) {
+  public static function get($array, $key, $default = null) {
 
     // get an array of keys
     if(is_array($key)) {
@@ -95,7 +95,7 @@ class A {
    * @param   boolean  $echo By default the result will be echoed instantly. You can switch that off here.
    * @return  mixed    If echo is false, this will return the generated array output.
    */
-  static public function show($array, $echo = true) {
+  public static function show($array, $echo = true) {
     return dump($array, $echo);
   }
 
@@ -119,7 +119,7 @@ class A {
    * @param   array   $array The source array
    * @return  string  The JSON string
    */
-  static public function json($array) {
+  public static function json($array) {
     return json_encode((array)$array);
   }
 
@@ -151,7 +151,7 @@ class A {
    * @param   int      $level The indendation level
    * @return  string   The XML string
    */
-  static public function xml($array, $tag = 'root', $head = true, $charset = 'utf-8', $tab = '  ', $level = 0) {
+  public static function xml($array, $tag = 'root', $head = true, $charset = 'utf-8', $tab = '  ', $level = 0) {
     return xml::create($array, $tag, $head, $charset, $tab, $level);
   }
 
@@ -189,7 +189,7 @@ class A {
    * @param   string  $key The key name of the column to extract
    * @return  array   The result array with all values from that column.
    */
-  static public function extract($array, $key) {
+  public static function extract($array, $key) {
     $output = array();
     foreach($array AS $a) if(isset($a[$key])) $output[] = $a[ $key ];
     return $output;
@@ -218,7 +218,7 @@ class A {
    * @param   array  $array The source array
    * @return  array  The shuffled result array
    */
-  static public function shuffle($array) {
+  public static function shuffle($array) {
 
     $keys = array_keys($array);
     $new  = array();
@@ -254,7 +254,7 @@ class A {
    * @param   array  $array The source array
    * @return  mixed  The first element
    */
-  static public function first($array) {
+  public static function first($array) {
     return array_shift($array);
   }
 
@@ -281,7 +281,7 @@ class A {
    * @param   array  $array The source array
    * @return  mixed  The last element
    */
-  static public function last($array) {
+  public static function last($array) {
     return array_pop($array);
   }
 
@@ -313,7 +313,7 @@ class A {
    * @param   mixed  $fill The element, which should be used to fill the array
    * @return  array  The filled-up result array
    */
-  static public function fill($array, $limit, $fill='placeholder') {
+  public static function fill($array, $limit, $fill='placeholder') {
     if(count($array) < $limit) {
       $diff = $limit-count($array);
       for($x=0; $x<$diff; $x++) $array[] = $fill;
@@ -348,7 +348,7 @@ class A {
    * @param   array  $required An array of required keys
    * @return  array  An array of missing fields. If this is empty, nothing is missing.
    */
-  static public function missing($array, $required=array()) {
+  public static function missing($array, $required=array()) {
     $missing = array();
     foreach($required AS $r) {
       if(empty($array[$r])) $missing[] = $r;
@@ -404,7 +404,7 @@ class A {
    * @param   const   $method A PHP sort method flag or 'natural' for natural sorting, which is not supported in PHP by sort flags
    * @return  array   The sorted array
    */
-  static public function sort($array, $field, $direction = 'desc', $method = SORT_REGULAR) {
+  public static function sort($array, $field, $direction = 'desc', $method = SORT_REGULAR) {
 
     $direction = strtolower($direction) == 'desc' ? SORT_DESC : SORT_ASC;
     $helper    = array();
@@ -436,7 +436,7 @@ class A {
    * @param   array    $array The array to analyze
    * @return  boolean  true: The array is associative false: It's not
    */
-  static public function isAssociative($array) {
+  public static function isAssociative($array) {
     return !ctype_digit(implode(NULL, array_keys($array)));
   }
 
@@ -447,7 +447,7 @@ class A {
    * @param   int    $decimals The number of decimals to return
    * @return  int    The average value
    */
-  static public function average($array, $decimals = 0) {
+  public static function average($array, $decimals = 0) {
     return round(array_sum($array), $decimals) / sizeof($array);
   }
 
@@ -458,7 +458,7 @@ class A {
    * @param array $array2
    * @return array
    */
-  static public function merge($array1, $array2) {
+  public static function merge($array1, $array2) {
     $merged = $array1;
     foreach($array2 as $key => $value) {
       if(is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {

--- a/lib/bitmask.php
+++ b/lib/bitmask.php
@@ -20,7 +20,7 @@ class Bitmask {
    * @return boolean
    */
   static public function validValue($value) {
-    return is_int($value) and ($value & ($value - 1)) == 0;
+    return is_int($value) && ($value & ($value - 1)) == 0;
   }
 
   /**

--- a/lib/bitmask.php
+++ b/lib/bitmask.php
@@ -19,7 +19,7 @@ class Bitmask {
    * @param  mixed   $value The value to check for
    * @return boolean
    */
-  static public function validValue($value) {
+  public static function validValue($value) {
     return is_int($value) && ($value & ($value - 1)) == 0;
   }
 
@@ -30,7 +30,7 @@ class Bitmask {
    * @param  int     $bitmask The bitmask to check in
    * @return boolean
    */
-  static public function includes($value, $bitmask) {
+  public static function includes($value, $bitmask) {
     if(!static::validValue($value)) return false;
 
     return ($bitmask & $value) !== 0;
@@ -43,7 +43,7 @@ class Bitmask {
    * @param  int     $bitmask The bitmask to add the value to
    * @return int
    */
-  static public function add($value, $bitmask) {
+  public static function add($value, $bitmask) {
     if(!static::validValue($value)) {
       throw new Exception('The value "' . $value . '" is not appropriate for usage in bitmasks.');
     }
@@ -61,7 +61,7 @@ class Bitmask {
    * @param  int     $bitmask The bitmask to remove the value from
    * @return int
    */
-  static public function remove($value, $bitmask) {
+  public static function remove($value, $bitmask) {
     if(!static::validValue($value)) {
       throw new Exception('The value "' . $value . '" is not appropriate for usage in bitmasks.');
     }

--- a/lib/brick.php
+++ b/lib/brick.php
@@ -2,7 +2,7 @@
 
 class Brick {
 
-  static public $bricks = array();
+  public static $bricks = array();
 
   public $tag    = null;
   public $attr   = array();
@@ -187,11 +187,11 @@ class Brick {
     return $this->toString();
   }
 
-  static public function make($id, $callback) {
+  public static function make($id, $callback) {
     static::$bricks[$id] = $callback;
   }
 
-  static public function get($id) {
+  public static function get($id) {
     if(!isset(static::$bricks[$id])) return false;
     $args = array_slice(func_get_args(), 1);
     return call_user_func_array(static::$bricks[$id], $args);

--- a/lib/c.php
+++ b/lib/c.php
@@ -13,5 +13,5 @@
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 class C extends Silo {
-  static public $data = array();
+  public static $data = array();
 }

--- a/lib/cache.php
+++ b/lib/cache.php
@@ -18,7 +18,7 @@ class Cache {
   const ERROR_INVALID_DRIVER_INSTANCE = 1;
   const ERROR_UNKNOWN_METHOD = 2;
 
-  static public $driver = null;
+  public static $driver = null;
 
   /**
    * Setup simplifier for the current driver
@@ -27,7 +27,7 @@ class Cache {
    * @param mixed $args
    * @return Cache\Driver
    */
-  static public function setup($driver, $args = null) {
+  public static function setup($driver, $args = null) {
     $ref  = new ReflectionClass('Cache\\Driver\\' . $driver);
     return static::$driver = $ref->newInstanceArgs(array($args));
   }
@@ -39,7 +39,7 @@ class Cache {
    * @param mixed $args
    * @return mixed
    */
-  static public function __callStatic($method, $args) {
+  public static function __callStatic($method, $args) {
 
     if(is_null(static::$driver)) {
       throw new Error('Please define a cache driver', static::ERROR_INVALID_DRIVER);

--- a/lib/cache/driver.php
+++ b/lib/cache/driver.php
@@ -105,7 +105,7 @@ abstract class Driver {
    * Checks when an item in the cache expires
    *
    * @param string $key
-   * @return int
+   * @return mixed
    */
   public function expires($key) {
     // get the Value object
@@ -132,7 +132,7 @@ abstract class Driver {
    * Checks when the cache has been created
    *
    * @param string $key
-   * @return int
+   * @return mixed
    */
   public function created($key) {
     // get the Value object

--- a/lib/cache/driver.php
+++ b/lib/cache/driver.php
@@ -38,7 +38,7 @@ abstract class Driver {
    * @param  int     $minutes
    * @return void
    */
-  abstract public function set($key, $value, $minutes = null);
+  public abstract function set($key, $value, $minutes = null);
 
   /**
    * Private method to retrieve the cache value
@@ -47,7 +47,7 @@ abstract class Driver {
    * @param string $key
    * @return object Value
    */
-  abstract public function retrieve($key);
+  public abstract function retrieve($key);
 
   /**
    * Get an item from the cache.
@@ -178,13 +178,13 @@ abstract class Driver {
    * @param string $key
    * @return boolean
    */
-  abstract public function remove($key);
+  public abstract function remove($key);
 
   /**
    * Flush the entire cache
    *
    * @return boolean
    */
-  abstract public function flush();
+  public abstract function flush();
 
 }

--- a/lib/cache/driver.php
+++ b/lib/cache/driver.php
@@ -22,7 +22,6 @@ abstract class Driver {
    * Set all parameters which are needed to connect to the cache storage
    *
    * @param array $params
-   * @return void
    */
   public function __construct($params = array()) {}
 
@@ -39,7 +38,7 @@ abstract class Driver {
    * @param  int     $minutes
    * @return void
    */
-  abstract function set($key, $value, $minutes = null);
+  abstract public function set($key, $value, $minutes = null);
 
   /**
    * Private method to retrieve the cache value
@@ -48,7 +47,7 @@ abstract class Driver {
    * @param string $key
    * @return object Value
    */
-  abstract function retrieve($key);
+  abstract public function retrieve($key);
 
   /**
    * Get an item from the cache.
@@ -179,13 +178,13 @@ abstract class Driver {
    * @param string $key
    * @return boolean
    */
-  abstract function remove($key);
+  abstract public function remove($key);
 
   /**
    * Flush the entire cache
    *
    * @return boolean
    */
-  abstract function flush();
+  abstract public function flush();
 
 }

--- a/lib/cache/driver/apc.php
+++ b/lib/cache/driver/apc.php
@@ -33,18 +33,9 @@ class Apc extends Driver {
   }
 
   /**
-   * Get an item from the cache.
-   *
-   * <code>
-   *    // Get an item from the cache driver
-   *    $value = Cache::get('value');
-   *
-   *    // Return a default value if the requested item isn't cached
-   *    $value = Cache::get('value', 'default value');
-   * </code>
+   * Retrieve an item from the cache.
    *
    * @param  string  $key
-   * @param  mixed   $default
    * @return mixed
    */
   public function retrieve($key) {

--- a/lib/cache/driver/file.php
+++ b/lib/cache/driver/file.php
@@ -25,7 +25,6 @@ class File extends Driver {
    * see defaults for available parameters
    *
    * @param array $params
-   * @return void
    */
   public function __construct($params = array()) {
 

--- a/lib/cache/driver/memcached.php
+++ b/lib/cache/driver/memcached.php
@@ -23,7 +23,6 @@ class Memcached extends Driver {
    * see defaults for available parameters
    *
    * @param array $params
-   * @return void
    */
   public function __construct($params = array()) {
 

--- a/lib/cache/driver/mock.php
+++ b/lib/cache/driver/mock.php
@@ -33,18 +33,9 @@ class Mock extends Driver {
   }
 
   /**
-   * Get an item from the cache.
-   *
-   * <code>
-   *    // Get an item from the cache driver
-   *    $value = Cache::get('value');
-   *
-   *    // Return a default value if the requested item isn't cached
-   *    $value = Cache::get('value', 'default value');
-   * </code>
+   * Retrieve an item from the cache.
    *
    * @param  string  $key
-   * @param  mixed   $default
    * @return mixed
    */
   public function retrieve($key) {

--- a/lib/cache/driver/session.php
+++ b/lib/cache/driver/session.php
@@ -71,7 +71,8 @@ class Session extends Driver {
    * @return boolean
    */
   public function flush() {
-    return $_SESSION['_cache'] = array();
+    $_SESSION['_cache'] = array();
+    return true;
   }
 
 }

--- a/lib/collection.php
+++ b/lib/collection.php
@@ -24,7 +24,7 @@ class Collection extends I {
    * @return Collection
    */
   public function slice($offset = null, $limit = null) {
-    if($offset === null and $limit === null) return $this;
+    if($offset === null && $limit === null) return $this;
     $collection = clone $this;
     $collection->data = array_slice($collection->data, $offset, $limit);
     return $collection;
@@ -248,7 +248,7 @@ class Collection extends I {
     $split      = @$args[2];
     $collection = clone $this;
 
-    if(is_string($value) and array_key_exists($value, static::$filters)) {
+    if(is_string($value) && array_key_exists($value, static::$filters)) {
       $operator = $value;
       $value    = @$args[2];
       $split    = @$args[3];
@@ -282,7 +282,7 @@ class Collection extends I {
    * @return mixed
    */
   static public function extractValue($item, $field) {
-    if(is_array($item) and isset($item[$field])) {
+    if(is_array($item) && isset($item[$field])) {
       return $item[$field];
     } else if(is_object($item)) {
       return $item->$field();
@@ -424,7 +424,7 @@ class Collection extends I {
       if(!$value) throw new Exception('Invalid grouping value for key: ' . $key);
 
       // make sure we have a proper key for each group
-      if(is_object($value) or is_array($value)) throw new Exception('You cannot group by arrays or objects');
+      if(is_object($value) || is_array($value)) throw new Exception('You cannot group by arrays or objects');
 
       // ignore upper/lowercase for group names
       if($i) $value = str::lower($value);
@@ -555,7 +555,7 @@ collection::$filters['*='] = function($collection, $field, $value, $split = fals
 };
 
 // greater than
-collection::$filters['>'] = function($collection, $field, $value, $split = false) {
+collection::$filters['>'] = function($collection, $field, $value) {
 
   foreach($collection->data as $key => $item) {
     if(collection::extractValue($item, $field) > $value) continue;
@@ -567,7 +567,7 @@ collection::$filters['>'] = function($collection, $field, $value, $split = false
 };
 
 // greater and equals
-collection::$filters['>='] = function($collection, $field, $value, $split = false) {
+collection::$filters['>='] = function($collection, $field, $value) {
 
   foreach($collection->data as $key => $item) {
     if(collection::extractValue($item, $field) >= $value) continue;
@@ -579,7 +579,7 @@ collection::$filters['>='] = function($collection, $field, $value, $split = fals
 };
 
 // less than
-collection::$filters['<'] = function($collection, $field, $value, $split = false) {
+collection::$filters['<'] = function($collection, $field, $value) {
 
   foreach($collection->data as $key => $item) {
     if(collection::extractValue($item, $field) < $value) continue;
@@ -591,7 +591,7 @@ collection::$filters['<'] = function($collection, $field, $value, $split = false
 };
 
 // less and equals
-collection::$filters['<='] = function($collection, $field, $value, $split = false) {
+collection::$filters['<='] = function($collection, $field, $value) {
 
   foreach($collection->data as $key => $item) {
     if(collection::extractValue($item, $field) <= $value) continue;

--- a/lib/collection.php
+++ b/lib/collection.php
@@ -11,8 +11,7 @@
  */
 class Collection extends I {
 
-  static public $filters = array();
-
+  public static $filters = array();
 
   protected $pagination;
 

--- a/lib/collection.php
+++ b/lib/collection.php
@@ -423,7 +423,15 @@ class Collection extends I {
       if(!$value) throw new Exception('Invalid grouping value for key: ' . $key);
 
       // make sure we have a proper key for each group
-      if(is_object($value) || is_array($value)) throw new Exception('You cannot group by arrays or objects');
+      if(is_array($value)) {
+        throw new Exception('You cannot group by arrays or objects');
+      } else if(is_object($value)) {
+        if(!method_exists($value, '__toString')) {
+          throw new Exception('You cannot group by arrays or objects');
+        } else {
+          $value = (string)$value;
+        }
+      } 
 
       // ignore upper/lowercase for group names
       if($i) $value = str::lower($value);

--- a/lib/collection.php
+++ b/lib/collection.php
@@ -256,6 +256,10 @@ class Collection extends I {
       $split    = @$args[3];
     }
 
+    if(is_object($value)) {
+      $value = (string)$value;
+    }
+
     if(array_key_exists($operator, static::$filters)) {
 
       $collection = call_user_func_array(static::$filters[$operator], array(

--- a/lib/collection.php
+++ b/lib/collection.php
@@ -1,7 +1,5 @@
 <?php
 
-if(!defined('SORT_NATURAL')) define('SORT_NATURAL', 'natural');
-
 /**
  * Collection
  *

--- a/lib/cookie.php
+++ b/lib/cookie.php
@@ -14,7 +14,7 @@
 class Cookie {
 
   // configuration
-  static public $salt = 'KirbyToolkitCookieSalt';
+  public static $salt = 'KirbyToolkitCookieSalt';
 
   /**
    * Set a new cookie
@@ -35,7 +35,7 @@ class Cookie {
    * @param  boolean $httpOnly avoids the cookie to be accessed via javascript
    * @return boolean true: the cookie has been created, false: cookie creation failed
    */
-  static public function set($key, $value, $expires = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true) {
+  public static function set($key, $value, $expires = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true) {
   
     // convert minutes to seconds    
     if($expires > 0) $expires = time() + ($expires * 60);
@@ -71,7 +71,7 @@ class Cookie {
    * @param  boolean $secure only sets the cookie over https
    * @return boolean true: the cookie has been created, false: cookie creation failed
    */
-  static public function forever($key, $value, $path = '/', $domain = null, $secure = false) {
+  public static function forever($key, $value, $path = '/', $domain = null, $secure = false) {
     return static::set($key, $value, 2628000, $path, $domain, $secure);
   }
 
@@ -89,7 +89,7 @@ class Cookie {
    * @param  string  $default The default value, which should be returned if the cookie has not been found
    * @return mixed   The found value
    */
-  static public function get($key = null, $default = null) {
+  public static function get($key = null, $default = null) {
     if(is_null($key)) return $_COOKIE;
     $value = isset($_COOKIE[$key]) ? $_COOKIE[$key] : null;
     return empty($value) ? $default : static::parse($value);
@@ -100,7 +100,7 @@ class Cookie {
    * 
    * @return boolean
    */
-  static public function exists($key) {
+  public static function exists($key) {
     return !is_null(static::get($key));
   }
 
@@ -111,7 +111,7 @@ class Cookie {
    * @param string $value
    * @return string
    */
-  static protected function hash($value) {
+  protected static function hash($value) {
     return sha1($value . static::$salt);
   }
 
@@ -122,7 +122,7 @@ class Cookie {
    * @param string $string
    * @return mixed
    */
-  static protected function parse($string) {
+  protected static function parse($string) {
 
     // extract hash and value
     $parts = str::split($string, '+');
@@ -152,7 +152,7 @@ class Cookie {
    * @param  string  $key The name of the cookie
    * @return mixed   true: the cookie has been removed, false: the cookie could not be removed
    */
-  static public function remove($key) {
+  public static function remove($key) {
     unset($_COOKIE[$key]);
     setcookie($key, '', 1);
     return setcookie($key, false);

--- a/lib/cookie.php
+++ b/lib/cookie.php
@@ -130,7 +130,7 @@ class Cookie {
     $value = a::last($parts);
 
     // if the hash or the value is missing at all return null
-    if(empty($hash) or empty($value)) return null;
+    if(empty($hash) || empty($value)) return null;
 
     // compare the extracted hash with the hashed value
     if($hash !== static::hash($value)) return null;

--- a/lib/cookie.php
+++ b/lib/cookie.php
@@ -28,18 +28,15 @@ class Cookie {
    * 
    * @param  string  $key The name of the cookie
    * @param  string  $value The cookie content
-   * @param  int     $expires The number of minutes until the cookie expires
+   * @param  int     $lifetime The number of minutes until the cookie expires
    * @param  string  $path The path on the server to set the cookie for
    * @param  string  $domain the domain 
    * @param  boolean $secure only sets the cookie over https
    * @param  boolean $httpOnly avoids the cookie to be accessed via javascript
    * @return boolean true: the cookie has been created, false: cookie creation failed
    */
-  public static function set($key, $value, $expires = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true) {
-  
-    // convert minutes to seconds    
-    if($expires > 0) $expires = time() + ($expires * 60);
-    
+  public static function set($key, $value, $lifetime = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true) {
+      
     // convert array values to json 
     if(is_array($value)) $value = a::json($value);
 
@@ -50,8 +47,17 @@ class Cookie {
     $_COOKIE[$key] = $value;
     
     // store the cookie
-    return setcookie($key, $value, $expires, $path, $domain, $secure, $httpOnly);
+    return setcookie($key, $value, static::lifetime($lifetime), $path, $domain, $secure, $httpOnly);
   
+  }
+
+  /**
+   * Calculates the lifetime for a cookie
+   * 
+   * @return int
+   */
+  public static function lifetime($minutes) {
+    return $minutes > 0 ? (time() + ($minutes * 60)) : 0;
   }
 
   /**
@@ -154,8 +160,7 @@ class Cookie {
    */
   public static function remove($key) {
     unset($_COOKIE[$key]);
-    setcookie($key, '', 1);
-    return setcookie($key, false);
+    return setcookie($key, null, -1, '/');
   }
 
 }

--- a/lib/crypt.php
+++ b/lib/crypt.php
@@ -1,8 +1,5 @@
 <?php
 
-// check for mcrypt support
-if(!function_exists('mcrypt_get_iv_size')) throw new Exception('The mcrypt extension is missing');
-
 /**
  * Crypt
  * 
@@ -15,65 +12,75 @@ if(!function_exists('mcrypt_get_iv_size')) throw new Exception('The mcrypt exten
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 class Crypt {
-		
-	// encryption salt - should be changed
-	static public $salt = '-';
+    
+  // encryption salt - should be changed
+  static public $salt = '-';
 
-	// all available encryption modes
-	static public $encryption = array(
-		'rijndael-128',
-		'rijndael-256',
-		'blowfish',
-		'twofish',
-		'des'
-	);
+  // all available encryption modes
+  static public $encryption = array(
+    'rijndael-128',
+    'rijndael-256',
+    'blowfish',
+    'twofish',
+    'des'
+  );
 
-	/**
-	 * Encodes a string
-	 * 
-	 * @param string $text
-	 * @param string $key An optional encryption key
-	 * @param string $mode Check out the $encryption array for available modes
-	 * @return string
-	 */
-	static public function encode($text, $key = null, $mode = 'blowfish') {
+  /**
+   * Encodes a string
+   * 
+   * @param string $text
+   * @param string $key An optional encryption key
+   * @param string $mode Check out the $encryption array for available modes
+   * @return string
+   */
+  static public function encode($text, $key = null, $mode = 'blowfish') {
 
-		// all modes are lowercase so we try to avoid errors here
-		$mode = strtolower($mode);
+    // check for mcrypt support
+    if(!function_exists('mcrypt_get_iv_size')) {
+      throw new Exception('The mcrypt extension is missing');
+    }
 
-		// check for a valid encryption mode
-		if(!in_array($mode, static::$encryption)) throw new Exception('Invalid encryption mode: ' . $mode);
+    // all modes are lowercase so we try to avoid errors here
+    $mode = strtolower($mode);
 
-		$size   = mcrypt_get_iv_size($mode, MCRYPT_MODE_ECB);
-		$iv     = mcrypt_create_iv($size, MCRYPT_RAND);
-		$result = mcrypt_encrypt($mode, static::$salt . $key, $text, MCRYPT_MODE_ECB, $iv);
-		
-		return trim($result);
+    // check for a valid encryption mode
+    if(!in_array($mode, static::$encryption)) throw new Exception('Invalid encryption mode: ' . $mode);
 
-	}
+    $size   = mcrypt_get_iv_size($mode, MCRYPT_MODE_ECB);
+    $iv     = mcrypt_create_iv($size, MCRYPT_RAND);
+    $result = mcrypt_encrypt($mode, static::$salt . $key, $text, MCRYPT_MODE_ECB, $iv);
+    
+    return trim($result);
 
-	/**
-	 * Decodes a string
-	 * 
-	 * @param string $text
-	 * @param string $key An optional encryption key
-	 * @param string $mode Check out the $encryption array for available modes
-	 * @return string
-	 */
-	static public function decode($text, $key = null, $mode = 'blowfish') {
+  }
 
-		// all modes are lowercase so we try to avoid errors here
-		$mode = strtolower($mode);
+  /**
+   * Decodes a string
+   * 
+   * @param string $text
+   * @param string $key An optional encryption key
+   * @param string $mode Check out the $encryption array for available modes
+   * @return string
+   */
+  static public function decode($text, $key = null, $mode = 'blowfish') {
 
-		// check for a valid encryption mode
-		if(!in_array($mode, static::$encryption)) throw new Exception('Invalid encryption mode: ' . $mode);
+    // check for mcrypt support
+    if(!function_exists('mcrypt_get_iv_size')) {
+      throw new Exception('The mcrypt extension is missing');
+    }
 
-		$size   = mcrypt_get_iv_size($mode, MCRYPT_MODE_ECB);
-		$iv     = mcrypt_create_iv($size, MCRYPT_RAND);
-		$result = mcrypt_decrypt($mode, static::$salt . $key, $text, MCRYPT_MODE_ECB, $iv);
-		
-		return trim($result);
+    // all modes are lowercase so we try to avoid errors here
+    $mode = strtolower($mode);
 
-	}
+    // check for a valid encryption mode
+    if(!in_array($mode, static::$encryption)) throw new Exception('Invalid encryption mode: ' . $mode);
+
+    $size   = mcrypt_get_iv_size($mode, MCRYPT_MODE_ECB);
+    $iv     = mcrypt_create_iv($size, MCRYPT_RAND);
+    $result = mcrypt_decrypt($mode, static::$salt . $key, $text, MCRYPT_MODE_ECB, $iv);
+    
+    return trim($result);
+
+  }
 
 }

--- a/lib/crypt.php
+++ b/lib/crypt.php
@@ -14,10 +14,10 @@
 class Crypt {
     
   // encryption salt - should be changed
-  static public $salt = '-';
+  public static $salt = '-';
 
   // all available encryption modes
-  static public $encryption = array(
+  public static $encryption = array(
     'rijndael-128',
     'rijndael-256',
     'blowfish',
@@ -33,7 +33,7 @@ class Crypt {
    * @param string $mode Check out the $encryption array for available modes
    * @return string
    */
-  static public function encode($text, $key = null, $mode = 'blowfish') {
+  public static function encode($text, $key = null, $mode = 'blowfish') {
 
     // check for mcrypt support
     if(!function_exists('mcrypt_get_iv_size')) {
@@ -62,7 +62,7 @@ class Crypt {
    * @param string $mode Check out the $encryption array for available modes
    * @return string
    */
-  static public function decode($text, $key = null, $mode = 'blowfish') {
+  public static function decode($text, $key = null, $mode = 'blowfish') {
 
     // check for mcrypt support
     if(!function_exists('mcrypt_get_iv_size')) {

--- a/lib/data.php
+++ b/lib/data.php
@@ -94,7 +94,14 @@ data::$adapters['kd'] = array(
     $result = array();
     foreach($data AS $key => $value) {
       $key = str::ucfirst(str::slug($key));
+
       if(empty($key) || is_null($value)) continue;
+
+      // avoid problems with arrays
+      if(is_array($value)) {
+        $value = '';
+      }
+
       // escape accidental dividers within a field
       $value = preg_replace('!\n----(.*?\R*)!', "\n ----$1", $value);
 

--- a/lib/data.php
+++ b/lib/data.php
@@ -16,9 +16,9 @@ class Data {
 
   const ERROR_INVALID_ADAPTER = 0;
 
-  static public $adapters = array();
+  public static $adapters = array();
 
-  static public function adapter($type) {
+  public static function adapter($type) {
 
     if(isset(static::$adapters[$type])) return static::$adapters[$type];
 
@@ -34,17 +34,17 @@ class Data {
 
   }
 
-  static public function encode($data, $type) {
+  public static function encode($data, $type) {
     $adapter = static::adapter($type);
     return call_user_func($adapter['encode'], $data);
   }
 
-  static public function decode($data, $type) {
+  public static function decode($data, $type) {
     $adapter = static::adapter($type);
     return call_user_func($adapter['decode'], $data);
   }
 
-  static public function read($file, $type = null) {
+  public static function read($file, $type = null) {
 
     // type autodetection
     if(is_null($type)) $type = f::extension($file);
@@ -61,7 +61,7 @@ class Data {
 
   }
 
-  static public function write($file, $data, $type = null) {
+  public static function write($file, $data, $type = null) {
     // type autodetection
     if(is_null($type)) $type = f::extension($file);
     return f::write($file, data::encode($data, $type));

--- a/lib/data.php
+++ b/lib/data.php
@@ -23,7 +23,7 @@ class Data {
     if(isset(static::$adapters[$type])) return static::$adapters[$type];
 
     foreach(static::$adapters as $adapter) {
-      if(is_array($adapter['extension']) and in_array($type, $adapter['extension'])) {
+      if(is_array($adapter['extension']) && in_array($type, $adapter['extension'])) {
         return $adapter;
       } else if($adapter['extension'] == $type) {
         return $adapter;
@@ -94,7 +94,7 @@ data::$adapters['kd'] = array(
     $result = array();
     foreach($data AS $key => $value) {
       $key = str::ucfirst(str::slug($key));
-      if(empty($key) or is_null($value)) continue;
+      if(empty($key) || is_null($value)) continue;
       // escape accidental dividers within a field
       $value = preg_replace('!\n----(.*?\R*)!', "\n ----$1", $value);
 
@@ -144,7 +144,7 @@ data::$adapters['php'] = array(
   'encode' => function($array) {
     return '<?php ' . PHP_EOL . PHP_EOL . 'return ' . var_export($array, true) . PHP_EOL . PHP_EOL . '?>';
   },
-  'decode' => function($string) {
+  'decode' => function() {
     throw new Error('Decoding PHP strings is not supported');
   },
   'read' => function($file) {

--- a/lib/database.php
+++ b/lib/database.php
@@ -391,7 +391,7 @@ class Database {
  */
 database::$connectors['mysql'] = function($params) {
 
-  if(!isset($params['host']) and !isset($params['socket'])) {
+  if(!isset($params['host']) && !isset($params['socket'])) {
     throw new Error('The mysql connection requires either a "host" or a "socket" parameter');
   } 
   

--- a/lib/database.php
+++ b/lib/database.php
@@ -14,10 +14,10 @@
  */
 class Database {
 
-  static public $connectors = array();
+  public static $connectors = array();
 
   // a global array of started connections
-  static public $connections = array();
+  public static $connections = array();
 
   // the established connection
   protected $connection;
@@ -71,7 +71,7 @@ class Database {
    * @param string $id
    * @return object
    */
-  static public function instance($id = null) {
+  public static function instance($id = null) {
     return (is_null($id)) ? a::last(static::$connections) : a::get(static::$connections, $id);
   }
 
@@ -80,7 +80,7 @@ class Database {
    *
    * @return array
    */
-  static public function instances() {
+  public static function instances() {
     return static::$connections;
   }
 

--- a/lib/database.php
+++ b/lib/database.php
@@ -28,6 +28,9 @@ class Database {
   // the database type (mysql, sqlite)
   protected $type;
 
+  // the connection id
+  protected $id;
+
   // the optional prefix for table names
   protected $prefix;
 

--- a/lib/database/query.php
+++ b/lib/database/query.php
@@ -341,9 +341,9 @@ class Query {
 
         } else if(is_callable($args[0])) {
 
-          $query  = clone $this;
-          $result = call_user_func($args[0], $query);
-          $where  = '(' . $query->where . ')';
+          $query = clone $this;
+          call_user_func($args[0], $query);
+          $where = '(' . $query->where . ')';
 
         }
 

--- a/lib/database/query.php
+++ b/lib/database/query.php
@@ -79,7 +79,7 @@ class Query {
   protected $debug = false;
 
   // an array with reserved sql values
-  static protected $literals = array('NOW()');
+  protected static $literals = array('NOW()');
 
   /**
    * Constructor

--- a/lib/database/query.php
+++ b/lib/database/query.php
@@ -540,7 +540,6 @@ class Query {
           'limit'    => $this->limit
         ));
 
-        break;
       case 'update':
 
         return $sql->update(array(
@@ -549,7 +548,6 @@ class Query {
           'values' => $this->values,
         ));
 
-        break;
       case 'insert':
 
         return $sql->insert(array(
@@ -557,7 +555,6 @@ class Query {
           'values' => $this->values,
         ));
 
-        break;
       case 'delete':
 
         return $sql->delete(array(
@@ -565,7 +562,6 @@ class Query {
           'where' => $this->where,
         ));
 
-        break;
     }
 
   }

--- a/lib/db.php
+++ b/lib/db.php
@@ -28,7 +28,7 @@ class DB {
    * @return object
    */
   static public function connect($params = null) {
-    if(is_null($params) and !is_null(static::$connection)) return static::$connection;
+    if(is_null($params) && !is_null(static::$connection)) return static::$connection;
     if(is_null($params)) {
 
       // try to connect with the default connection settings

--- a/lib/db.php
+++ b/lib/db.php
@@ -16,10 +16,10 @@ class DB {
   const ERROR_UNKNOWN_METHOD = 0;
 
   // query shortcuts
-  static public $queries = array();
+  public static $queries = array();
 
   // The singleton Database object
-  static public $connection = null;
+  public static $connection = null;
 
   /**
    * (Re)connect the database
@@ -27,7 +27,7 @@ class DB {
    * @param mixed $params Pass array() to use the default params from the config
    * @return object
    */
-  static public function connect($params = null) {
+  public static function connect($params = null) {
     if(is_null($params) && !is_null(static::$connection)) return static::$connection;
     if(is_null($params)) {
 
@@ -51,7 +51,7 @@ class DB {
    *
    * @return object
    */
-  static public function connection() {
+  public static function connection() {
     return static::$connection;
   }
 
@@ -61,7 +61,7 @@ class DB {
    * @param string $table
    * @return object Returns a DBQuery object, which can be used to build a full query for that table
    */
-  static public function table($table) {
+  public static function table($table) {
     $connection = db::connect();
     return $connection->table($table);
   }
@@ -74,7 +74,7 @@ class DB {
    * @param array $params
    * @return mixed
    */
-  static public function query($query, $bindings = array(), $params = array()) {
+  public static function query($query, $bindings = array(), $params = array()) {
     $connection = db::connect();
     return $connection->query($query, $bindings, $params);
   }
@@ -86,7 +86,7 @@ class DB {
    * @param array $bindings
    * @return mixed
    */
-  static public function execute($query, $bindings = array()) {
+  public static function execute($query, $bindings = array()) {
     $connection = db::connect();
     return $connection->execute($query, $bindings);
   }
@@ -99,7 +99,7 @@ class DB {
    * @param mixed $arguments
    * @return mixed
    */
-  static public function __callStatic($method, $arguments) {
+  public static function __callStatic($method, $arguments) {
 
     if(isset(static::$queries[$method])) {
       return call(static::$queries[$method], $arguments);

--- a/lib/detect.php
+++ b/lib/detect.php
@@ -57,7 +57,7 @@ class Detect {
    * @return boolean
    */
   static public function iis() {
-    return isset($_SERVER['SERVER_SOFTWARE']) and strpos($_SERVER['SERVER_SOFTWARE'],'IIS') !== false ? true : false;  
+    return isset($_SERVER['SERVER_SOFTWARE']) && strpos($_SERVER['SERVER_SOFTWARE'],'IIS') !== false ? true : false;  
   }    
 
   /**
@@ -235,7 +235,7 @@ class Detect {
    */
   static public function ios() {
     $ua = visitor::ua();
-    return (str::contains($ua, 'iPod') or str::contains($ua, 'iPhone') or str::contains($ua, 'iPad'));
+    return (str::contains($ua, 'iPod') || str::contains($ua, 'iPhone') || str::contains($ua, 'iPad'));
   }
   
 }

--- a/lib/detect.php
+++ b/lib/detect.php
@@ -19,7 +19,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function mbstring() { 
+  public static function mbstring() { 
     return function_exists('mb_split');
   }
 
@@ -29,7 +29,7 @@ class Detect {
    * @param mixed $min
    * @return boolean
    */
-  static public function php($min = '5.3') {
+  public static function php($min = '5.3') {
     return version_compare(PHP_VERSION, $min, '>=');
   }
 
@@ -38,7 +38,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function apache() {
+  public static function apache() {
     return apache_get_version() ? true : false;
   }
 
@@ -47,7 +47,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function windows() {
+  public static function windows() {
     return DS == '/' ? false : true;
   }
 
@@ -56,7 +56,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function iis() {
+  public static function iis() {
     return isset($_SERVER['SERVER_SOFTWARE']) && strpos($_SERVER['SERVER_SOFTWARE'],'IIS') !== false ? true : false;  
   }    
 
@@ -66,7 +66,7 @@ class Detect {
    * @param mixed $min
    * @return boolean
    */
-  static public function mysql($min = '5') {
+  public static function mysql($min = '5') {
     $extensions = get_loaded_extensions();
     if(!in_array('mysql', $extensions)) return false;      
     $version = preg_replace('#(^\D*)([0-9.]+).*$#', '\2', mysql_get_client_info());
@@ -78,7 +78,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function sqlite() {
+  public static function sqlite() {
     return in_array('sqlite3', get_loaded_extensions());                          
   }
 
@@ -87,7 +87,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function safemode() {
+  public static function safemode() {
     return ini_get('safe_mode');
   }
   
@@ -96,7 +96,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function gdlib() {
+  public static function gdlib() {
     return function_exists('gd_info');
   }
 
@@ -105,7 +105,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function imagick() {
+  public static function imagick() {
     return class_exists('Imagick');    
   }
 
@@ -114,7 +114,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function curl() {
+  public static function curl() {
     return in_array('curl', get_loaded_extensions());                          
   }  
 
@@ -123,7 +123,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function apc() {
+  public static function apc() {
     return function_exists('apc_add');
   }
 
@@ -132,7 +132,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function memcache() {
+  public static function memcache() {
     return class_exists('Memcache');
   }
 
@@ -141,7 +141,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function memcached() {
+  public static function memcached() {
     return class_exists('Memcached');
   }
 
@@ -150,7 +150,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function imap() {
+  public static function imap() {
     return function_exists('imap_body');
   }
 
@@ -159,7 +159,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function mcrypt() {
+  public static function mcrypt() {
     return function_exists('mcrypt_encrypt');
   }
 
@@ -168,7 +168,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function exif() {
+  public static function exif() {
     return function_exists('read_exif_data');
   }
 
@@ -177,7 +177,7 @@ class Detect {
    * 
    * @return string
    */
-  static public function subfolder() {
+  public static function subfolder() {
     return trim(dirname($_SERVER['SCRIPT_NAME']), '/\\');
   }
 
@@ -186,7 +186,7 @@ class Detect {
    * 
    * @return string
    */
-  static public function path() {
+  public static function path() {
     $uri    = explode('/', url::path());
     $script = explode('/', trim($_SERVER['SCRIPT_NAME'], '/\\'));    
     $parts  = array_diff_assoc($uri, $script);
@@ -199,7 +199,7 @@ class Detect {
    * 
    * @return string
    */
-  static public function documentRoot() {    
+  public static function documentRoot() {    
     $local    = $_SERVER['SCRIPT_NAME'];
     $absolute = $_SERVER['SCRIPT_FILENAME'];
     return substr($absolute, 0, strpos($absolute, $local));     
@@ -211,7 +211,7 @@ class Detect {
    *
    * @return int
    */
-  static public function maxUploadSize() {
+  public static function maxUploadSize() {
 
     $size = ini_get('post_max_size');
     $size = trim($size);
@@ -233,7 +233,7 @@ class Detect {
    * 
    * @return boolean
    */
-  static public function ios() {
+  public static function ios() {
     $ua = visitor::ua();
     return (str::contains($ua, 'iPod') || str::contains($ua, 'iPhone') || str::contains($ua, 'iPad'));
   }

--- a/lib/dimensions.php
+++ b/lib/dimensions.php
@@ -91,7 +91,7 @@ class Dimensions {
    */
   public function fit($box, $force = false) {
 
-    if($this->width == 0 or $this->height == 0) {
+    if($this->width == 0 || $this->height == 0) {
       $this->width  = $box;
       $this->height = $box;
       return $this;
@@ -100,10 +100,10 @@ class Dimensions {
     $ratio = $this->ratio();
 
     if($this->width > $this->height) {
-      if($this->width > $box || $force == true) $this->width = $box;
+      if($this->width > $box || $force === true) $this->width = $box;
       $this->height = round($this->width / $ratio);
     } elseif($this->height > $this->width) {
-      if($this->height > $box || $force == true) $this->height = $box;
+      if($this->height > $box || $force === true) $this->height = $box;
       $this->width = round($this->height * $ratio);
     } elseif($this->width > $box) {
       $this->width  = $box;
@@ -139,7 +139,7 @@ class Dimensions {
 
     if(!$fit) return $this;
 
-    if($this->width <= $fit and !$force) return $this;
+    if($this->width <= $fit && !$force) return $this;
 
     $ratio = $this->ratio();
 
@@ -175,7 +175,7 @@ class Dimensions {
 
     if(!$fit) return $this;
 
-    if($this->height <= $fit and !$force) return $this;
+    if($this->height <= $fit && !$force) return $this;
 
     $ratio = $this->ratio();
 

--- a/lib/dimensions.php
+++ b/lib/dimensions.php
@@ -131,7 +131,7 @@ class Dimensions {
    *
    * </code>
    *
-   * @param int $width the max width
+   * @param int $fit the max width
    * @param boolean $force If true, the dimensions will be upscaled to fit the width if smaller
    * @return object returns this object with recalculated dimensions
    */
@@ -167,7 +167,7 @@ class Dimensions {
    *
    * </code>
    *
-   * @param int $height the max height
+   * @param int $fit the max height
    * @param boolean $force If true, the dimensions will be upscaled to fit the height if smaller
    * @return object returns this object with recalculated dimensions
    */

--- a/lib/dir.php
+++ b/lib/dir.php
@@ -130,7 +130,6 @@ class Dir {
    * Returns a nicely formatted size of all the contents of the folder
    *
    * @param string $dir The path of the directory
-   * @param boolean $recursive
    * @return mixed
    */
   static public function niceSize($dir) {

--- a/lib/dir.php
+++ b/lib/dir.php
@@ -167,7 +167,7 @@ class Dir {
     foreach($content as $item) {
       $subdir = $dir . DS . $item;
       if(filemtime($subdir) > $time) return true;
-      if(is_dir($subdir) and dir::wasModifiedAfter($subdir, $time)) return true;
+      if(is_dir($subdir) && dir::wasModifiedAfter($subdir, $time)) return true;
     }
 
     return false;
@@ -200,7 +200,7 @@ class Dir {
    * @param string $dir Source path
    * @param string $to Destination path
    */
-  static function copy($dir, $to) {
+  static public function copy($dir, $to) {
     // It's easier to handle this with the Folder class
     $object = new Folder($dir);
     return $object->copy($to);

--- a/lib/dir.php
+++ b/lib/dir.php
@@ -13,7 +13,7 @@
  */
 class Dir {
 
-  static public $defaults = array(
+  public static $defaults = array(
     'permissions' => 0755,
     'ignore'      => array('.', '..', '.DS_Store', '.gitignore', '.git', '.svn', '.htaccess', 'Thumb.db', '@eaDir')
   );
@@ -32,7 +32,7 @@ class Dir {
    * @param   string  $dir The path for the new directory
    * @return  boolean True: the dir has been created, false: creating failed
    */
-  static public function make($dir, $recursive = true) {
+  public static function make($dir, $recursive = true) {
     return is_dir($dir) ? true : @mkdir($dir, static::$defaults['permissions'], $recursive);
   }
 
@@ -51,7 +51,7 @@ class Dir {
    * @param   array   $ignore Optional array with filenames, which should be ignored
    * @return  mixed   An array of filenames or false
    */
-  static public function read($dir, $ignore = array()) {
+  public static function read($dir, $ignore = array()) {
     if(!is_dir($dir)) return array();
     $skip = array_merge(static::$defaults['ignore'], $ignore);
     return (array)array_diff(scandir($dir),$skip);
@@ -72,7 +72,7 @@ class Dir {
    * @param   string  $new The desired path where the dir should be moved to
    * @return  boolean True: the directory has been moved, false: moving failed
    */
-  static public function move($old, $new) {
+  public static function move($old, $new) {
     if(!is_dir($old)) return false;
     return @rename($old, $new);
   }
@@ -92,7 +92,7 @@ class Dir {
    * @param   boolean  $keep If set to true, the directory will flushed but not removed.
    * @return  boolean  True: the directory has been removed, false: removing failed
    */
-  static public function remove($dir, $keep = false) {
+  public static function remove($dir, $keep = false) {
     if(!is_dir($dir)) return false;
 
     // It's easier to handle this with the Folder class
@@ -106,7 +106,7 @@ class Dir {
    * @param   string   $dir The path of the directory
    * @return  boolean  True: the directory has been flushed, false: flushing failed
    */
-  static public function clean($dir) {
+  public static function clean($dir) {
     return static::remove($dir, true);
   }
 
@@ -116,7 +116,7 @@ class Dir {
    * @param   string $dir The path of the directory
    * @return  mixed
    */
-  static public function size($dir) {
+  public static function size($dir) {
 
     if(!file_exists($dir)) return false;
 
@@ -132,7 +132,7 @@ class Dir {
    * @param string $dir The path of the directory
    * @return mixed
    */
-  static public function niceSize($dir) {
+  public static function niceSize($dir) {
     return f::niceSize(static::size($dir));
   }
 
@@ -144,7 +144,7 @@ class Dir {
    * @param   string   $format
    * @return  int
    */
-  static public function modified($dir, $format = null) {
+  public static function modified($dir, $format = null) {
     // It's easier to handle this with the Folder class
     $object = new Folder($dir);
     return $object->modified($format);
@@ -158,7 +158,7 @@ class Dir {
    * @param int $time
    * @return boolean
    */
-  static public function wasModifiedAfter($dir, $time) {
+  public static function wasModifiedAfter($dir, $time) {
 
     if(filemtime($dir) > $time) return true;
 
@@ -180,7 +180,7 @@ class Dir {
    * @param string $dir
    * @return boolean
    */
-  static public function writable($dir) {
+  public static function writable($dir) {
     return is_writable($dir);
   }
 
@@ -190,7 +190,7 @@ class Dir {
    * @param string $dir
    * @return boolean
    */
-  static public function readable($dir) {
+  public static function readable($dir) {
     return is_readable($dir);
   }
 
@@ -200,7 +200,7 @@ class Dir {
    * @param string $dir Source path
    * @param string $to Destination path
    */
-  static public function copy($dir, $to) {
+  public static function copy($dir, $to) {
     // It's easier to handle this with the Folder class
     $object = new Folder($dir);
     return $object->copy($to);

--- a/lib/email.php
+++ b/lib/email.php
@@ -78,7 +78,7 @@ class Email extends Obj {
       if(static::$disabled) throw new Error('Sending emails is disabled', static::ERROR_DISABLED);
 
       // overwrite already set values
-      if(is_array($params) and !empty($params)) {
+      if(is_array($params) && !empty($params)) {
         if(isset($params['service'])) $this->service = $params['service'];
         if(isset($params['options'])) $this->options = $params['options'];
         if(isset($params['to']))      $this->to      = $params['to'];

--- a/lib/email.php
+++ b/lib/email.php
@@ -23,8 +23,8 @@ class Email extends Obj {
   const ERROR_INVALID_SERVICE = 5;
   const ERROR_DISABLED = 6;
 
-  static public $services = array();
-  static public $disabled = false;
+  public static $services = array();
+  public static $disabled = false;
 
   public $error = null;
 

--- a/lib/embed.php
+++ b/lib/embed.php
@@ -21,7 +21,7 @@ class Embed {
    * @param array $attr Additional attributes for the iframe
    * @return string
    */
-  static public function youtube($url, $attr = array()) {
+  public static function youtube($url, $attr = array()) {
 
     // http://www.youtube.com/embed/d9NF2edxy-M
     if(preg_match('!youtube.com\/embed\/([a-z0-9_-]+)!i', $url, $array)) {
@@ -59,7 +59,7 @@ class Embed {
    * @param array $attr Additional attributes for the iframe
    * @return string
    */
-  static public function vimeo($url, $attr = array()) {
+  public static function vimeo($url, $attr = array()) {
 
     // get the uid from the url
     if(preg_match('!vimeo.com\/([0-9]+)!i', $url, $array)) {
@@ -93,7 +93,7 @@ class Embed {
    * @param string $file The name of a particular file from the gist, which should displayed only.
    * @return string
    */
-  static public function gist($url, $file = null) {
+  public static function gist($url, $file = null) {
 
     // url for the script file
     $url = $url . '.js' . r(!is_null($file), '?file=' . $file);

--- a/lib/errorreporting.php
+++ b/lib/errorreporting.php
@@ -18,7 +18,7 @@ class ErrorReporting {
    *
    * @return int     The current value
    */
-  static public function get() {
+  public static function get() {
     return error_reporting();
   }
 
@@ -28,7 +28,7 @@ class ErrorReporting {
    * @param  int     $level The new level to set
    * @return int     The new value
    */
-  static public function set($level) {
+  public static function set($level) {
     if(static::get() !== error_reporting($level)) {
       throw new Exception('Internal error: error_reporting() did not return the old value.');
     }
@@ -42,7 +42,7 @@ class ErrorReporting {
    * @param  int     $current A custom current level
    * @return boolean
    */
-  static public function includes($level, $current = null) {
+  public static function includes($level, $current = null) {
     // also allow strings
     if(is_string($level)) {
       if(defined($level)) {
@@ -64,7 +64,7 @@ class ErrorReporting {
    * @param  int     $level The level to add
    * @return boolean
    */
-  static public function add($level) {
+  public static function add($level) {
     // check if it is already added
     if(static::includes($level)) return false;
 
@@ -81,7 +81,7 @@ class ErrorReporting {
    * @param  int     $level The level to remove
    * @return boolean
    */
-  static public function remove($level) {
+  public static function remove($level) {
     // check if it is already removed
     if(!static::includes($level)) return false;
 

--- a/lib/escape.php
+++ b/lib/escape.php
@@ -26,7 +26,7 @@ class Escape {
    * @param  string  $string
    * @return boolean
    */
-  static public function noNeedToEscape($string) {
+  public static function noNeedToEscape($string) {
     return $string === '' || ctype_digit($string);
   }
   
@@ -36,7 +36,7 @@ class Escape {
    * @param  string $char
    * @return string
    */
-  static public function convertEncoding($char) {
+  public static function convertEncoding($char) {
     return str::convert($char, 'UTF-16BE', 'UTF-8');
   }
   
@@ -46,7 +46,7 @@ class Escape {
    * @param  string $char
    * @return boolean
    */
-  static public function charIsUndefined($char) {
+  public static function charIsUndefined($char) {
     $ascii = ord($char);
     return ($ascii <= 0x1f && $char != "\t" && $char != "\n" && $char != "\r")
       || ($ascii >= 0x7f && $ascii <= 0x9f);
@@ -69,7 +69,7 @@ class Escape {
    * @param  string $string
    * @return string
    */
-  static public function html($string) {
+  public static function html($string) {
     $flags = ENT_QUOTES;
     if(defined('ENT_SUBSTITUTE')) {
       $flags |= ENT_SUBSTITUTE;
@@ -96,7 +96,7 @@ class Escape {
    * @param  string $string
    * @return string 
    */
-  static public function xml($string) {
+  public static function xml($string) {
     if (defined('ENT_XML1')) {
       return htmlspecialchars($string, ENT_QUOTES | ENT_XML1, 'UTF-8');
     } else {
@@ -124,7 +124,7 @@ class Escape {
    *                        which is necessary in case of unquoted HTML attributes.
    * @return string
    */
-  static public function attr($string, $strict = false) {
+  public static function attr($string, $strict = false) {
     if(static::noNeedToEscape($string)) return $string;
     if($strict !== true) {
       return preg_replace_callback('/[^a-z0-9,\.\-_]/iSu', 'static::escapeAttrChar', $string);
@@ -145,7 +145,7 @@ class Escape {
    * @param  string $string
    * @return string
    */
-  static public function js($string) {
+  public static function js($string) {
     if(static::noNeedToEscape($string)) return $string;
     return preg_replace_callback('/[^a-z0-9,\._]/iSu', 'static::escapeJSChar', $string);
   }
@@ -166,7 +166,7 @@ class Escape {
    * @param  string $string
    * @return string
    */
-  static public function css($string) {
+  public static function css($string) {
     if(static::noNeedToEscape($string)) return $string;
     return preg_replace_callback('/[^a-z0-9]/iSu', 'static::escapeCSSChar', $string);
   }
@@ -182,7 +182,7 @@ class Escape {
    * @param string  $string
    * @return string
    */
-  static public function url($string) {
+  public static function url($string) {
     return rawurlencode($string);
   }
   
@@ -198,7 +198,7 @@ class Escape {
    *               upper hex entity if a named entity does not exist or
    *               entity with the &#xHH; format if ASCII value is less than 256.
    */
-  static protected function escapeAttrChar($matches) {
+  protected static function escapeAttrChar($matches) {
     $char = $matches[0];
     
     if(static::charIsUndefined($char)) {
@@ -234,7 +234,7 @@ class Escape {
    * @param  array  $matches
    * @return string
    */
-  static protected function escapeJSChar($matches) {
+  protected static function escapeJSChar($matches) {
     $char = $matches[0];
     if(str::length($char) == 1) {
       return sprintf('\\x%02X', ord($char));
@@ -252,7 +252,7 @@ class Escape {
    * @param  array  $matches
    * @return string
    */
-  static protected function escapeCSSChar($matches) {
+  protected static function escapeCSSChar($matches) {
     $char = $matches[0];
     if(str::length($char) == 1) {
       $ord = ord($char);

--- a/lib/escape.php
+++ b/lib/escape.php
@@ -126,7 +126,7 @@ class Escape {
    */
   static public function attr($string, $strict = false) {
     if(static::noNeedToEscape($string)) return $string;
-    if($strict) {
+    if($strict !== true) {
       return preg_replace_callback('/[^a-z0-9,\.\-_]/iSu', 'static::escapeAttrChar', $string);
     }
     return static::html($string);

--- a/lib/exif/camera.php
+++ b/lib/exif/camera.php
@@ -19,8 +19,7 @@ class Camera {
   /**
    * Constructor
    *
-   * @param string $make
-   * @param string $model
+   * @param array $exif
    */
   public function __construct($exif) {
     $this->make  = @$exif['Make'];

--- a/lib/exif/location.php
+++ b/lib/exif/location.php
@@ -71,7 +71,7 @@ class Location {
     $seconds = count($coord) > 2 ? $this->num($coord[2]) : 0;
 
     $hemi = strtoupper($hemi);
-    $flip = ($hemi == 'W' or $hemi == 'S') ? -1 : 1;
+    $flip = ($hemi == 'W' || $hemi == 'S') ? -1 : 1;
 
     return $flip * ($degrees + $minutes / 60 + $seconds / 3600);
 

--- a/lib/f.php
+++ b/lib/f.php
@@ -381,7 +381,9 @@ class F {
   static public function extension($file, $extension = false) {
 
     // overwrite the current extension
-    if($extension) return static::name($file) . '.' . $extension;
+    if($extension !== false) {
+      return static::name($file) . '.' . $extension;
+    }
 
     // return the current extension
     return strtolower(pathinfo($file, PATHINFO_EXTENSION));

--- a/lib/f.php
+++ b/lib/f.php
@@ -523,7 +523,7 @@ class F {
    * Returns the mime type of a file
    *
    * @param string $file
-   * @return string
+   * @return mixed
    */
   static public function mime($file) {
 

--- a/lib/f.php
+++ b/lib/f.php
@@ -14,7 +14,7 @@
  */
 class F {
 
-  static public $mimes = array(
+  public static $mimes = array(
     'hqx'   => 'application/mac-binhex40',
     'cpt'   => 'application/mac-compactpro',
     'csv'   => array('text/x-comma-separated-values', 'text/comma-separated-values', 'application/octet-stream'),
@@ -116,7 +116,7 @@ class F {
     'odp'   => 'application/vnd.oasis.opendocument.presentation',
   );
 
-  static public $types = array(
+  public static $types = array(
 
     'image' => array(
       'jpeg',
@@ -220,14 +220,14 @@ class F {
    * @param string $file
    * @return boolean
    */
-  static public function exists($file) {
+  public static function exists($file) {
     return file_exists($file);
   }
 
   /**
    * Safely requires a file if it exists
    */
-  static public function load($file, $data = array()) {
+  public static function load($file, $data = array()) {
     if(file_exists($file)) {
       extract($data);
       require($file);
@@ -253,7 +253,7 @@ class F {
    * @param  boolean $append true: append the content to an exisiting file if available. false: overwrite.
    * @return boolean
    */
-  static public function write($file, $content, $append = false) {
+  public static function write($file, $content, $append = false) {
     if(is_array($content) || is_object($content)) $content = serialize($content);
     $mode = ($append) ? FILE_APPEND | LOCK_EX : LOCK_EX;
     // if the parent directory does not exist, create it
@@ -270,7 +270,7 @@ class F {
    * @param  mixed   $content Either a string or an array. Arrays will be converted to JSON.
    * @return boolean
    */
-  static public function append($file, $content) {
+  public static function append($file, $content) {
     return static::write($file,$content,true);
   }
 
@@ -290,7 +290,7 @@ class F {
    * @param  string $file The path for the file
    * @return mixed
    */
-  static public function read($file) {
+  public static function read($file) {
     return @file_get_contents($file);
   }
 
@@ -300,7 +300,7 @@ class F {
    * @param string $file The path for the file
    * @return string
    */
-  static public function base64($file) {
+  public static function base64($file) {
     return base64_encode(f::read($file));
   }
 
@@ -310,7 +310,7 @@ class F {
    * @param string $file The path for the file
    * @return string
    */
-  static public function uri($file) {
+  public static function uri($file) {
     $mime = static::mime($file);
     return ($mime) ? 'data:' . $mime . ';base64,' . static::base64($file) : false;
   }
@@ -330,7 +330,7 @@ class F {
    * @param  string $new The path to the new location
    * @return boolean
    */
-  static public function move($old, $new) {
+  public static function move($old, $new) {
     if(!file_exists($old) || file_exists($new)) return false;
     return @rename($old, $new);
   }
@@ -342,7 +342,7 @@ class F {
    * @param  string  $target
    * @return boolean
    */
-  static public function copy($file, $target) {
+  public static function copy($file, $target) {
     if(!file_exists($file) || file_exists($target)) return false;
     return @copy($file, $target);
   }
@@ -360,7 +360,7 @@ class F {
    * @param  string  $file The path for the file
    * @return boolean
    */
-  static public function remove($file) {
+  public static function remove($file) {
     return file_exists($file) && is_file($file) && !empty($file) ? @unlink($file) : false;
   }
 
@@ -378,7 +378,7 @@ class F {
    * @param  string  $extension Set an optional extension to overwrite the current one
    * @return string
    */
-  static public function extension($file, $extension = false) {
+  public static function extension($file, $extension = false) {
 
     // overwrite the current extension
     if($extension !== false) {
@@ -396,7 +396,7 @@ class F {
    * @param string $type
    * @return array
    */
-  static public function extensions($type = null) {
+  public static function extensions($type = null) {
     if(is_null($type)) return array_keys(static::$mimes);
     return isset(static::$types[$type]) ? static::$types[$type] : array();
   }
@@ -414,7 +414,7 @@ class F {
    * @param  string  $name The path
    * @return string
    */
-  static public function filename($name) {
+  public static function filename($name) {
     return pathinfo($name, PATHINFO_BASENAME);
   }
 
@@ -432,7 +432,7 @@ class F {
    * @param  string  $name The path or filename
    * @return string
    */
-  static public function name($name) {
+  public static function name($name) {
     return pathinfo($name, PATHINFO_FILENAME);
   }
 
@@ -449,7 +449,7 @@ class F {
    * @param  string  $file The path
    * @return string
    */
-  static public function dirname($file) {
+  public static function dirname($file) {
     return dirname($file);
   }
 
@@ -466,7 +466,7 @@ class F {
    * @param  mixed  $file The path
    * @return mixed
    */
-  static public function size($file) {
+  public static function size($file) {
     return filesize($file);
   }
 
@@ -486,7 +486,7 @@ class F {
    * @param  mixed $size The file size or a file path
    * @return string
    */
-  static public function niceSize($size) {
+  public static function niceSize($size) {
 
     // file mode
     if(is_string($size) && file_exists($size)) {
@@ -515,7 +515,7 @@ class F {
    * @param string $handler date or strftime
    * @return int
    */
-  static public function modified($file, $format = null, $handler = 'date') {
+  public static function modified($file, $format = null, $handler = 'date') {
     return !is_null($format) ? $handler($format, filemtime($file)) : filemtime($file);
   }
 
@@ -525,7 +525,7 @@ class F {
    * @param string $file
    * @return mixed
    */
-  static public function mime($file) {
+  public static function mime($file) {
 
     // stop for invalid files
     if(!file_exists($file)) return null;
@@ -557,7 +557,7 @@ class F {
    *
    * @return array
    */
-  static public function mimes() {
+  public static function mimes() {
     return static::$mimes;
   }
 
@@ -567,7 +567,7 @@ class F {
    * @param string $file Either the file path or extension
    * @return string
    */
-  static public function type($file) {
+  public static function type($file) {
 
     $length = strlen($file);
 
@@ -601,7 +601,7 @@ class F {
    *
    * @return array
    */
-  static public function types() {
+  public static function types() {
     return static::$types;
   }
 
@@ -612,7 +612,7 @@ class F {
    * @param string $value An extension or mime type
    * @return boolean
    */
-  static public function is($file, $value) {
+  public static function is($file, $value) {
 
     if(in_array($value, static::extensions())) {
       // check for the extension
@@ -632,7 +632,7 @@ class F {
    * @param string $mime
    * @return string
    */
-  static public function mimeToExtension($mime) {
+  public static function mimeToExtension($mime) {
     foreach(static::$mimes as $key => $value) {
       if(is_array($value) && in_array($mime, $value)) return $key;
       if($value == $mime) return $key;
@@ -646,7 +646,7 @@ class F {
    * @param string $mime
    * @return string
    */
-  static public function mimeToType($mime) {
+  public static function mimeToType($mime) {
     return static::extensionToType(static::mimeToExtension($mime));
   }
 
@@ -656,7 +656,7 @@ class F {
    * @param string $extension
    * @return string
    */
-  static public function extensionToMime($extension) {
+  public static function extensionToMime($extension) {
     $mime = isset(static::$mimes[$extension]) ? static::$mimes[$extension] : null;
     return is_array($mime) ? array_shift($mime) : $mime;
   }
@@ -667,7 +667,7 @@ class F {
    * @param string $extension
    * @return string
    */
-  static public function extensionToType($extension) {
+  public static function extensionToType($extension) {
 
     // get all categorized types
     foreach(static::$types as $type => $extensions) {
@@ -691,7 +691,7 @@ class F {
    * @param  string $string The file name
    * @return string
    */
-  static public function safeName($string) {
+  public static function safeName($string) {
     $name      = static::name($string);
     $extension = static::extension($string);
     $end       = !empty($extension) ? '.' . str::slug($extension) : '';
@@ -704,7 +704,7 @@ class F {
    * @param string $file
    * @return boolean
    */
-  static public function isWritable($file) {
+  public static function isWritable($file) {
     return is_writable($file);
   }
 
@@ -714,7 +714,7 @@ class F {
    * @param string $file
    * @return boolean
    */
-  static public function isReadable($file) {
+  public static function isReadable($file) {
     return is_readable($file);
   }
 
@@ -723,7 +723,7 @@ class F {
    *
    * @param string $file
    */
-  static public function show($file) {
+  public static function show($file) {
 
     // stop the download if the file does not exist or is not readable
     if(!is_file($file) || !is_readable($file)) return false;
@@ -743,7 +743,7 @@ class F {
    * @param string $file The root to the file
    * @param string $name Optional filename for the download
    */
-  static public function download($file, $name = null) {
+  public static function download($file, $name = null) {
 
     // stop the download if the file does not exist or is not readable
     if(!is_file($file) || !is_readable($file)) return false;

--- a/lib/f.php
+++ b/lib/f.php
@@ -463,7 +463,7 @@ class F {
    *
    * </code>
    *
-   * @param  string  $file The path
+   * @param  mixed  $file The path
    * @return mixed
    */
   static public function size($file) {

--- a/lib/f.php
+++ b/lib/f.php
@@ -411,7 +411,7 @@ class F {
    *
    * </code>
    *
-   * @param  string  $file The path
+   * @param  string  $name The path
    * @return string
    */
   static public function filename($name) {

--- a/lib/f.php
+++ b/lib/f.php
@@ -481,13 +481,13 @@ class F {
    *
    * </code>
    *
-   * @param  int $size The file size or a file path
+   * @param  mixed $size The file size or a file path
    * @return string
    */
   static public function niceSize($size) {
 
     // file mode
-    if(!is_int($size) and file_exists($size)) {
+    if(is_string($size) and file_exists($size)) {
       $size = static::size($size);
     }
 

--- a/lib/f.php
+++ b/lib/f.php
@@ -254,7 +254,7 @@ class F {
    * @return boolean
    */
   static public function write($file, $content, $append = false) {
-    if(is_array($content) or is_object($content)) $content = serialize($content);
+    if(is_array($content) || is_object($content)) $content = serialize($content);
     $mode = ($append) ? FILE_APPEND | LOCK_EX : LOCK_EX;
     // if the parent directory does not exist, create it
     if(!is_dir(dirname($file))) {
@@ -331,7 +331,7 @@ class F {
    * @return boolean
    */
   static public function move($old, $new) {
-    if(!file_exists($old) or file_exists($new)) return false;
+    if(!file_exists($old) || file_exists($new)) return false;
     return @rename($old, $new);
   }
 
@@ -343,7 +343,7 @@ class F {
    * @return boolean
    */
   static public function copy($file, $target) {
-    if(!file_exists($file) or file_exists($target)) return false;
+    if(!file_exists($file) || file_exists($target)) return false;
     return @copy($file, $target);
   }
 
@@ -361,7 +361,7 @@ class F {
    * @return boolean
    */
   static public function remove($file) {
-    return file_exists($file) and is_file($file) and !empty($file) ? @unlink($file) : false;
+    return file_exists($file) && is_file($file) && !empty($file) ? @unlink($file) : false;
   }
 
   /**
@@ -489,7 +489,7 @@ class F {
   static public function niceSize($size) {
 
     // file mode
-    if(is_string($size) and file_exists($size)) {
+    if(is_string($size) && file_exists($size)) {
       $size = static::size($size);
     }
 
@@ -539,7 +539,7 @@ class F {
     }
 
     // for older versions with mime_content_type go for that.
-    if(function_exists('mime_content_type') and $mime = @mime_content_type($file) !== false) {
+    if(function_exists('mime_content_type') && $mime = @mime_content_type($file) !== false) {
       return $mime;
     }
 
@@ -571,7 +571,7 @@ class F {
 
     $length = strlen($file);
 
-    if($length >= 2 and $length <= 4) {
+    if($length >= 2 && $length <= 4) {
       // use the file name as extension
       $extension = $file;
     } else {
@@ -634,7 +634,7 @@ class F {
    */
   static public function mimeToExtension($mime) {
     foreach(static::$mimes as $key => $value) {
-      if(is_array($value) and in_array($mime, $value)) return $key;
+      if(is_array($value) && in_array($mime, $value)) return $key;
       if($value == $mime) return $key;
     }
     return null;
@@ -726,7 +726,7 @@ class F {
   static public function show($file) {
 
     // stop the download if the file does not exist or is not readable
-    if(!is_file($file) or !is_readable($file)) return false;
+    if(!is_file($file) || !is_readable($file)) return false;
 
     // send the browser headers
     header::type(f::mime($file));
@@ -746,7 +746,7 @@ class F {
   static public function download($file, $name = null) {
 
     // stop the download if the file does not exist or is not readable
-    if(!is_file($file) or !is_readable($file)) return false;
+    if(!is_file($file) || !is_readable($file)) return false;
 
     header::download(array(
       'name'     => $name ? $name : f::filename($file),

--- a/lib/f.php
+++ b/lib/f.php
@@ -429,7 +429,7 @@ class F {
    *
    * </code>
    *
-   * @param  string  $file The path or filename
+   * @param  string  $name The path or filename
    * @return string
    */
   static public function name($name) {

--- a/lib/f.php
+++ b/lib/f.php
@@ -495,10 +495,10 @@ class F {
     $size = (int)$size;
 
     // avoid errors for invalid sizes
-    if($size <= 0) return '0 kb';
+    if($size <= 0) return '0 kB';
 
     // available units
-    $unit = array('b','kb','mb','gb','tb','pb', 'eb', 'zb', 'yb');
+    $unit = array('B','kB','MB','GB','TB','PB', 'EB', 'ZB', 'YB');
 
     // the math magic
     return round($size / pow(1024, ($i = floor(log($size, 1024)))), 2) . ' ' . $unit[$i];

--- a/lib/folder.php
+++ b/lib/folder.php
@@ -148,7 +148,7 @@ class Folder {
    * 
    * @param array $ignore
    * @param boolean $plain
-   * @return Collection
+   * @return mixed When $plain is true an array will be returned. Otherwise a Collection
    */
   public function files($ignore = null, $plain = false) {
 
@@ -183,7 +183,7 @@ class Folder {
    * 
    * @param array $ignore
    * @param boolean $plain
-   * @return Collection
+   * @return mixed If $plain is true an array will be returned. Otherwise a Collection
    */
   public function children($ignore = null, $plain = false) {
 

--- a/lib/folder.php
+++ b/lib/folder.php
@@ -21,7 +21,7 @@ class Folder {
    * Constructor
    */
   public function __construct($root) {
-    if(file_exists($root) and is_file($root)) throw new Exception('Invalid folder: ' . $root);
+    if(file_exists($root) && is_file($root)) throw new Exception('Invalid folder: ' . $root);
     $this->root = $root;
   }
 

--- a/lib/header.php
+++ b/lib/header.php
@@ -14,7 +14,7 @@
 class Header {
 
   // configuration
-  static public $codes = array(
+  public static $codes = array(
     
     // successful
     '_200' => 'OK', 
@@ -51,7 +51,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function contentType($mime, $charset = 'UTF-8', $send = true) {  
+  public static function contentType($mime, $charset = 'UTF-8', $send = true) {  
     if(f::extensionToMime($mime)) $mime = f::extensionToMime($mime);
     $header = 'Content-type: ' . $mime;
     if($charset) $header .= '; charset=' . $charset;
@@ -67,7 +67,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function type($mime, $charset = 'UTF-8', $send = true) {
+  public static function type($mime, $charset = 'UTF-8', $send = true) {
     return static::contentType($mime, $charset, $send);
   }
 
@@ -78,7 +78,7 @@ class Header {
    * @param boolean $send If set to false the header will be returned instead
    * @return mixed
    */
-  static public function status($code, $send = true) {
+  public static function status($code, $send = true) {
 
     $codes    = static::$codes;
     $code     = !array_key_exists('_' . $code, $codes) ? 400 : $code;
@@ -99,7 +99,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function success($send = true) {
+  public static function success($send = true) {
     return static::status(200, $send);
   }
 
@@ -109,7 +109,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function created($send = true) {
+  public static function created($send = true) {
     return static::status(201, $send);
   }
 
@@ -119,7 +119,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function accepted($send = true) {
+  public static function accepted($send = true) {
     return static::status(202, $send);
   }
 
@@ -129,7 +129,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function error($send = true) {
+  public static function error($send = true) {
     return static::status(400, $send);
   }
 
@@ -139,7 +139,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function forbidden($send = true) {
+  public static function forbidden($send = true) {
     return static::status(403, $send);
   }
 
@@ -149,7 +149,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function notfound($send = true) {
+  public static function notfound($send = true) {
     return static::status(404, $send);
   }
 
@@ -159,7 +159,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function missing($send = true) {
+  public static function missing($send = true) {
     return static::status(404, $send);
   }
 
@@ -169,7 +169,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function panic($send = true) {
+  public static function panic($send = true) {
     return static::status(500, $send);
   }
 
@@ -179,7 +179,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function unavailable($send = true) {
+  public static function unavailable($send = true) {
     return static::status(503, $send);
   }
 
@@ -189,7 +189,7 @@ class Header {
    * @param boolean $send
    * @return mixed
    */
-  static public function redirect($url, $code = 301, $send = true) {
+  public static function redirect($url, $code = 301, $send = true) {
 
     $status   = static::status($code, false); 
     $location = 'Location:' . $url;
@@ -209,7 +209,7 @@ class Header {
    * 
    * @param array $params Check out the defaults array for available parameters
    */
-  static public function download($params = array()) {
+   public static function download($params = array()) {
 
     $defaults = array(
       'name'     => 'download',

--- a/lib/html.php
+++ b/lib/html.php
@@ -185,7 +185,7 @@ class Html {
       return implode(' ', $attributes);
     }
 
-    if(empty($value) and $value !== '0' and $value !== 0) {
+    if(empty($value) && $value !== '0' && $value !== 0) {
       return false;
     } else if(is_bool($value)) {
       return $value === true ? strtolower($name) : '';
@@ -218,7 +218,7 @@ class Html {
    * @return string the generated html
    */
   static public function email($email, $text = null, $attr = array()) {
-    $email = str::encode($email, 3);
+    $email = str::encode($email);
     $attr  = array_merge(array('href' => 'mailto:' . $email), $attr);
     if(empty($text)) $text = $email;
     return static::tag('a', $text, $attr);

--- a/lib/html.php
+++ b/lib/html.php
@@ -102,7 +102,9 @@ class Html {
    */
   static public function encode($string, $keepTags = true) {
     if($keepTags) {
-      return stripslashes(implode('', preg_replace_callback('/^([^<].+[^>])$/', create_function('$match', 'return htmlentities($match[1], ENT_COMPAT, "utf-8");'), preg_split('/(<.+?>)/', $string, -1, PREG_SPLIT_DELIM_CAPTURE))));
+      return stripslashes(implode('', preg_replace_callback('/^([^<].+[^>])$/', function($match) {
+        return htmlentities($match[1], ENT_COMPAT, 'utf-8');
+      }, preg_split('/(<.+?>)/', $string, -1, PREG_SPLIT_DELIM_CAPTURE))));
     } else {
       return htmlentities($string, ENT_COMPAT, 'utf-8');
     }

--- a/lib/html.php
+++ b/lib/html.php
@@ -210,7 +210,7 @@ class Html {
   /**
    * Generates an "a mailto" tag
    *
-   * @param string $href The url for the a tag
+   * @param string $email The url for the a tag
    * @param mixed $text The optional text. If null, the url will be used as text
    * @param array $attr Additional attributes for the tag
    * @return string the generated html

--- a/lib/html.php
+++ b/lib/html.php
@@ -18,7 +18,7 @@ class Html {
    *
    * @return array
    */
-  static public $entities = array(
+  public static $entities = array(
     '&nbsp;' => '&#160;', '&iexcl;' => '&#161;', '&cent;' => '&#162;', '&pound;' => '&#163;', '&curren;' => '&#164;', '&yen;' => '&#165;', '&brvbar;' => '&#166;', '&sect;' => '&#167;',
     '&uml;' => '&#168;', '&copy;' => '&#169;', '&ordf;' => '&#170;', '&laquo;' => '&#171;', '&not;' => '&#172;', '&shy;' => '&#173;', '&reg;' => '&#174;', '&macr;' => '&#175;',
     '&deg;' => '&#176;', '&plusmn;' => '&#177;', '&sup2;' => '&#178;', '&sup3;' => '&#179;', '&acute;' => '&#180;', '&micro;' => '&#181;', '&para;' => '&#182;', '&middot;' => '&#183;',
@@ -59,7 +59,7 @@ class Html {
    * @param string $tag
    * @return param
    */
-  static public function isVoid($tag) {
+  public static function isVoid($tag) {
 
     $void = array(
       'area', 
@@ -89,7 +89,7 @@ class Html {
    *
    * @return array
    */
-  static public function entities() {
+  public static function entities() {
     return static::$entities;
   }
 
@@ -100,7 +100,7 @@ class Html {
    * @param  boolean $keepTags True: lets stuff inside html tags untouched.
    * @return string  The html string
    */
-  static public function encode($string, $keepTags = true) {
+  public static function encode($string, $keepTags = true) {
     if($keepTags) {
       return stripslashes(implode('', preg_replace_callback('/^([^<].+[^>])$/', function($match) {
         return htmlentities($match[1], ENT_COMPAT, 'utf-8');
@@ -123,7 +123,7 @@ class Html {
    * @param  string  $string
    * @return string  The html string
    */
-  static public function decode($string) {
+  public static function decode($string) {
     $string = strip_tags($string);
     return html_entity_decode($string, ENT_COMPAT, 'utf-8');
   }
@@ -134,7 +134,7 @@ class Html {
    * @param string $string
    * @return string
    */
-  static public function breaks($string) {
+  public static function breaks($string) {
     return nl2br($string);
   }
 
@@ -146,7 +146,7 @@ class Html {
    * @param array $attr An associative array with additional attributes for the tag
    * @return string The generated Html
    */
-  static public function tag($name, $content = null, $attr = array()) {
+  public static function tag($name, $content = null, $attr = array()) {
 
     if(is_array($content)) {
       $attr    = $content;
@@ -175,7 +175,7 @@ class Html {
    * @param string $value if used for a single attribute, pass the content for the attribute here
    * @return string the generated html
    */
-  static public function attr($name, $value = null) {
+  public static function attr($name, $value = null) {
     if(is_array($name)) {
       $attributes = array();
       foreach($name as $key => $val) {
@@ -203,7 +203,7 @@ class Html {
    * @param array $attr Additional attributes for the tag
    * @return string the generated html
    */
-  static public function a($href, $text = null, $attr = array()) {
+  public static function a($href, $text = null, $attr = array()) {
     $attr = array_merge(array('href' => $href), $attr);
     if(empty($text)) $text = $href;
     return static::tag('a', $text, $attr);
@@ -217,7 +217,7 @@ class Html {
    * @param array $attr Additional attributes for the tag
    * @return string the generated html
    */
-  static public function email($email, $text = null, $attr = array()) {
+  public static function email($email, $text = null, $attr = array()) {
     $email = str::encode($email);
     $attr  = array_merge(array('href' => 'mailto:' . $email), $attr);
     if(empty($text)) $text = $email;
@@ -231,7 +231,7 @@ class Html {
    * @param array $attr Additional attributes for the image tag
    * @return string the generated html
    */
-  static public function img($src, $attr = array()) {
+  public static function img($src, $attr = array()) {
     $attr = array_merge(array('src' => $src, 'alt' => pathinfo($src, PATHINFO_FILENAME)), $attr);
     return static::tag('img', null, $attr);
   }
@@ -241,7 +241,7 @@ class Html {
    *
    * @return string the generated html
    */
-  static public function shiv() {
+  public static function shiv() {
     return '<!--[if lt IE 9]>' . PHP_EOL .
            '<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>' . PHP_EOL .
            '<![endif]-->' . PHP_EOL;

--- a/lib/l.php
+++ b/lib/l.php
@@ -13,5 +13,5 @@
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 class L extends Silo {
-  static public $data = array();
+  public static $data = array();
 }

--- a/lib/media.php
+++ b/lib/media.php
@@ -29,11 +29,8 @@ class Media {
   // the content of the file
   protected $content = null;
 
-  // cache for the exif object
-  protected $exif = null;
-
-  // cache for the dimensions object
-  protected $dimensions = null;
+  // cache for various data
+  protected $cache = array();
 
   /**
    * Constructor
@@ -46,6 +43,13 @@ class Media {
     $this->filename  = basename($root);
     $this->name      = pathinfo($root, PATHINFO_FILENAME);
     $this->extension = strtolower(pathinfo($root, PATHINFO_EXTENSION));
+  }
+
+  /**
+   * Resets the internal cache
+   */
+  public function reset() {
+    $this->cache = array();
   }
 
   /**
@@ -281,7 +285,6 @@ class Media {
   /**
    * Returns the mime type of a file
    *
-   * @param string $file
    * @return string
    */
   public function mime() {
@@ -382,8 +385,6 @@ class Media {
 
   /**
    * Read and send the file with the correct headers
-   *
-   * @param string $file
    */
   public function show() {
     f::show($this->root);
@@ -405,8 +406,8 @@ class Media {
    * @return Exif
    */
   public function exif() {
-    if(!is_null($this->exif)) return $this->exif;
-    return $this->exif = new Exif($this);
+    if(isset($this->cache['exif'])) return $this->cache['exif'];
+    return $this->cache['exif'] = new Exif($this);
   }
 
   /**

--- a/lib/media.php
+++ b/lib/media.php
@@ -516,7 +516,7 @@ class Media {
     $img = new Brick('img');
     $img->attr('src', $this->url());
 
-    if(is_string($attr) or (is_object($attr) and method_exists($attr, '__toString'))) {
+    if(is_string($attr) || (is_object($attr) && method_exists($attr, '__toString'))) {
       $img->attr('alt', (string)$attr);
     } else if(is_array($attr)) {
       $img->attr($attr);      

--- a/lib/pagination.php
+++ b/lib/pagination.php
@@ -12,7 +12,7 @@
 class Pagination {
 
   // configuration
-  static public $defaults = array(
+  public static $defaults = array(
     'variable'      => 'page',
     'method'        => 'param',
     'omitFirstPage' => true,

--- a/lib/pagination.php
+++ b/lib/pagination.php
@@ -47,7 +47,7 @@ class Pagination {
   /**
    * Constructor
    *
-   * @param object $data The collection with all data (KirbyFiles or KirbyPages)
+   * @param mixed $count Either an integer or a Collection
    * @param int $limit The number of items per page
    * @param array $params Additional parameters to control the pagination object
    */
@@ -59,10 +59,10 @@ class Pagination {
     }
 
     $this->options = array_merge(static::$defaults, $params);
-    $this->count   = $count;
-    $this->limit   = $limit;
-    $this->pages   = ceil($this->count / $this->limit);
-    $this->offset  = ($this->page()-1) * $this->limit;
+    $this->count   = (int)$count;
+    $this->limit   = (int)$limit;
+    $this->pages   = (int)ceil($this->count / $this->limit);
+    $this->offset  = (int)(($this->page()-1) * $this->limit);
 
   }
 
@@ -344,8 +344,8 @@ class Pagination {
       return range($this->rangeStart, $this->rangeEnd);
     }
 
-    $this->rangeStart = $this->page - floor($range/2);
-    $this->rangeEnd   = $this->page + floor($range/2);
+    $this->rangeStart = $this->page - (int)floor($range/2);
+    $this->rangeEnd   = $this->page + (int)floor($range/2);
 
     if($this->rangeStart <= 0) {
       $this->rangeEnd += abs($this->rangeStart)+1;

--- a/lib/pagination.php
+++ b/lib/pagination.php
@@ -18,6 +18,7 @@ class Pagination {
     'omitFirstPage' => true,
     'page'          => false,
     'url'           => null,
+    'redirect'      => false,
   );
 
   // options
@@ -84,15 +85,36 @@ class Pagination {
     // make sure the page is an int
     $this->page = intval($this->page);
 
+    // set the first page correctly
+    if($this->page == 0) {
+      $this->page = 1;
+    }
+
     // sanitize the page if too low
-    if($this->page < 1) $this->page = 1;
+    if($this->page < 1) {
+      $this->redirect();
+      $this->page = 1;
+    }
 
     // sanitize the page if too high
-    if($this->page > $this->pages && $this->count > 0) $this->page = $this->lastPage();
+    if($this->page > $this->pages && $this->count > 0) {
+      $this->redirect();
+      $this->page = $this->lastPage();
+    }
 
     // return the sanitized page number
     return $this->page;
 
+  }
+
+  /**
+   * Redirects to an error page if the redirect option is set
+   * and the pagination is beyond the allowed boundaries
+   */
+  public function redirect() {
+    if($redirect = $this->options['redirect']) {
+      go($redirect);
+    }
   }
 
   /**

--- a/lib/pagination.php
+++ b/lib/pagination.php
@@ -175,7 +175,7 @@ class Pagination {
 
       $query = url::query($this->options['url']);
 
-      if($page == 1 and $this->options['omitFirstPage']) {
+      if($page == 1 && $this->options['omitFirstPage']) {
         unset($query[$this->options['variable']]);
       } else {
         $query[$this->options['variable']] = $page;
@@ -187,7 +187,7 @@ class Pagination {
 
       $params = url::params($this->options['url']);
 
-      if($page == 1 and $this->options['omitFirstPage']) {
+      if($page == 1 && $this->options['omitFirstPage']) {
         unset($params[$this->options['variable']]);
       } else {
         $params[$this->options['variable']] = $page;

--- a/lib/password.php
+++ b/lib/password.php
@@ -19,7 +19,7 @@ class Password {
    * @param string $plaintext
    * @return string
    */
-  static public function hash($plaintext) {
+  public static function hash($plaintext) {
     $salt = substr(str_replace('+', '.', base64_encode(sha1(str::random(), true))), 0, 22);
     return crypt($plaintext, '$2a$10$' . $salt);
   }
@@ -30,7 +30,7 @@ class Password {
    * @param string
    * @return boolean
    */
-  static public function isHash($hash) {
+  public static function isHash($hash) {
     return preg_match('!^\$2a\$10\$!', $hash);
   }
 
@@ -41,7 +41,7 @@ class Password {
    * @param string $hash
    * @return boolean
    */
-  static public function match($plaintext, $hash) {
+  public static function match($plaintext, $hash) {
     return crypt($plaintext, $hash) === $hash;
   }  
 

--- a/lib/r.php
+++ b/lib/r.php
@@ -14,20 +14,20 @@
 class R {
 
   // Stores the raw request data
-  static protected $raw = null;
+  protected static $raw = null;
 
   // Stores all sanitized request data
-  static protected $data = null;
+  protected static $data = null;
 
   // the request body
-  static protected $body = null;
+  protected static $body = null;
 
   /**
    * Returns the raw request data
    *
    * @return array
    */
-  static public function raw() {
+  public static function raw() {
     if(!is_null(static::$raw)) return static::$raw;
     return static::$raw = array_merge($_GET, $_POST);
   }
@@ -49,7 +49,7 @@ class R {
    * @param mixed $default A default value, which will be returned if nothing can be found for a given key
    * @param mixed
    */
-  static public function data($key = null, $default = null) {
+  public static function data($key = null, $default = null) {
 
     if(is_null(static::$data)) {
       static::$data = static::sanitize(static::raw());
@@ -84,7 +84,7 @@ class R {
    *
    * @return array
    */
-  static public function getData($key = null, $default = null) {
+  public static function getData($key = null, $default = null) {
     return a::get((array)static::sanitize($_GET), $key, $default);
   }
 
@@ -93,7 +93,7 @@ class R {
    *
    * @return array
    */
-  static public function postData($key = null, $default = null) {
+  public static function postData($key = null, $default = null) {
     return a::get((array)static::sanitize($_POST), $key, $default);
   }
 
@@ -103,7 +103,7 @@ class R {
    * @param array $data
    * @return array
    */
-  static protected function sanitize($data) {
+  protected static function sanitize($data) {
 
     if(!is_array($data)) {
       return trim(str::stripslashes($data));
@@ -137,7 +137,7 @@ class R {
    * @param mixed $value The value
    * @return array
    */
-  static public function set($key, $value = null) {
+  public static function set($key, $value = null) {
 
     // set multiple values at once
     if(is_array($key)) {
@@ -174,7 +174,7 @@ class R {
    * @param mixed $default A default value, which will be returned if nothing can be found for a given key
    * @param mixed
    */
-  static public function get($key = null, $default = null) {
+  public static function get($key = null, $default = null) {
     return static::data($key, $default);
   }
 
@@ -183,7 +183,7 @@ class R {
    *
    * @param string $key
    */
-  static public function remove($key) {
+  public static function remove($key) {
     unset(static::$data[$key]);
   }
 
@@ -192,7 +192,7 @@ class R {
    *
    * @return string POST, GET, DELETE, PUT, HEAD, PATCH, etc.
    */
-  static public function method() {
+  public static function method() {
     return isset($_SERVER['REQUEST_METHOD']) ? strtoupper($_SERVER['REQUEST_METHOD']) : 'GET';
   }
 
@@ -201,7 +201,7 @@ class R {
    *
    * @return mixed
    */
-  static public function body() {
+  public static function body() {
     if(!is_null(static::$body)) return static::$body;
     return static::$body = file_get_contents('php://input');
   }
@@ -213,7 +213,7 @@ class R {
    * @param mixed $default A default value, which will be returned if nothing can be found for a given key
    * @return array
    */
-  static public function files($key = null, $default = null) {
+  public static function files($key = null, $default = null) {
     return a::get($_FILES, $key, $default);
   }
 
@@ -229,7 +229,7 @@ class R {
    *
    * @return boolean
    */
-  static public function is($method) {
+  public static function is($method) {
     if($method == 'ajax') {
       return static::ajax();
     } else {
@@ -242,7 +242,7 @@ class R {
    *
    * @return boolean
    */
-  static public function has($key) {
+  public static function has($key) {
     $data = static::data();
     return isset($data[$key]);
   }
@@ -260,7 +260,7 @@ class R {
    * @param string $default Pass an optional URL to use as default referer if no referer is being found
    * @return string
    */
-  static public function referer($default = null) {
+  public static function referer($default = null) {
     return a::get($_SERVER, 'HTTP_REFERER', $default);
   }
 
@@ -278,7 +278,7 @@ class R {
    * @param string $default Pass an optional URL to use as default referer if no referer is being found
    * @return string
    */
-  static public function referrer($default = null) {
+  public static function referrer($default = null) {
     return static::referer($default);
   }
 
@@ -288,7 +288,7 @@ class R {
    *
    * @param mixed
    */
-  static public function ip() {
+  public static function ip() {
     return isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : false;
   }
 
@@ -297,7 +297,7 @@ class R {
    *
    * @return boolean
    */
-  static public function cli() {
+  public static function cli() {
     return defined('STDIN') || (substr(PHP_SAPI, 0, 3) == 'cgi' && $term = getenv('TERM') && $term !== 'unknown');
   }
 
@@ -312,7 +312,7 @@ class R {
    *
    * @return boolean
    */
-  static public function ajax() {
+  public static function ajax() {
     return (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest');
   }
 
@@ -321,7 +321,7 @@ class R {
    *
    * @return string
    */
-  static public function scheme() {
+  public static function scheme() {
     return url::scheme();
   }
 
@@ -330,7 +330,7 @@ class R {
    *
    * @return boolean
    */
-  static public function ssl() {
+  public static function ssl() {
     return static::scheme() == 'https';
   }
 
@@ -339,7 +339,7 @@ class R {
    *
    * @return boolean
    */
-  static public function secure() {
+  public static function secure() {
     return static::ssl();
   }
 

--- a/lib/r.php
+++ b/lib/r.php
@@ -56,7 +56,7 @@ class R {
 
       if(!static::is('GET')) {
         $body = static::body();
-        @parse_str($body, $parsed);
+        parse_str($body, $parsed);
 
         if(!is_array($parsed)) {
           $parsed = json_decode($body, false);

--- a/lib/r.php
+++ b/lib/r.php
@@ -85,7 +85,7 @@ class R {
    * @return array
    */
   static public function getData($key = null, $default = null) {
-    return a::get(static::sanitize($_GET), $key, $default);
+    return a::get((array)static::sanitize($_GET), $key, $default);
   }
 
   /**
@@ -94,7 +94,7 @@ class R {
    * @return array
    */
   static public function postData($key = null, $default = null) {
-    return a::get(static::sanitize($_POST), $key, $default);
+    return a::get((array)static::sanitize($_POST), $key, $default);
   }
 
   /**
@@ -199,7 +199,7 @@ class R {
   /**
    * Returns the request body from POST requests for example
    *
-   * @return array
+   * @return mixed
    */
   static public function body() {
     if(!is_null(static::$body)) return static::$body;

--- a/lib/r.php
+++ b/lib/r.php
@@ -298,7 +298,7 @@ class R {
    * @return boolean
    */
   static public function cli() {
-    return defined('STDIN') or (substr(PHP_SAPI, 0, 3) == 'cgi' and $term = getenv('TERM') and $term !== 'unknown');
+    return defined('STDIN') || (substr(PHP_SAPI, 0, 3) == 'cgi' && $term = getenv('TERM') && $term !== 'unknown');
   }
 
   /**
@@ -313,7 +313,7 @@ class R {
    * @return boolean
    */
   static public function ajax() {
-    return (isset($_SERVER['HTTP_X_REQUESTED_WITH']) and strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest');
+    return (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest');
   }
 
   /**

--- a/lib/redirect.php
+++ b/lib/redirect.php
@@ -21,7 +21,7 @@ class Redirect {
    * @param   boolean   $code The HTTP status code, which should be sent (301, 302 or 303)
    * @param   boolean   $send If true, headers will be sent and redirection will take effect
    */
-  static public function send($url = false, $code = false, $send = true) {
+  public static function send($url = false, $code = false, $send = true) {
     return header::redirect($url, $code, $send);
   }
 
@@ -29,14 +29,14 @@ class Redirect {
    * Redirects to a specific URL. You can pass either a normal URI
    * a controller path or simply nothing (which redirects home)
    */
-  static public function to() {
+  public static function to() {
     static::send(call_user_func_array(array('url', 'to'), func_get_args()));
   }
 
   /**
    * Redirects to the home page of the app
    */
-  static public function home() {
+  public static function home() {
     static::send(url::home());
   }
 
@@ -45,7 +45,7 @@ class Redirect {
    * 
    * @param string $fallback
    */
-  static public function back($fallback = null) {
+  public static function back($fallback = null) {
     // get the last url
     $last = url::last();
     // make sure there's a proper fallback

--- a/lib/redirect.php
+++ b/lib/redirect.php
@@ -28,9 +28,6 @@ class Redirect {
   /**
    * Redirects to a specific URL. You can pass either a normal URI
    * a controller path or simply nothing (which redirects home)
-   * 
-   * @param string $uri
-   * @param array $arguments
    */
   static public function to() {
     static::send(call_user_func_array(array('url', 'to'), func_get_args()));

--- a/lib/remote.php
+++ b/lib/remote.php
@@ -308,7 +308,7 @@ class Remote {
    */
   protected function postfields($data) {
 
-    if(is_object($data) or is_array($data)) {
+    if(is_object($data) || is_array($data)) {
       return http_build_query($data);
     } else {
       return $data;

--- a/lib/remote.php
+++ b/lib/remote.php
@@ -15,7 +15,7 @@
 class Remote {
 
   // configuration
-  static public $defaults = array(
+  public static $defaults = array(
     'method'   => 'GET',
     'data'     => array(),
     'file'     => null,
@@ -181,7 +181,7 @@ class Remote {
    * @param array $params
    * @return object Response
    */
-  static public function request($url, $params = array()) {
+  public static function request($url, $params = array()) {
     $request = new self($url, $params);
     return $request->response();
   }
@@ -193,7 +193,7 @@ class Remote {
    * @param array $params
    * @return object Response
    */
-  static public function get($url, $params = array()) {
+  public static function get($url, $params = array()) {
 
     $defaults = array(
       'method' => 'GET',
@@ -222,7 +222,7 @@ class Remote {
    * @param array $params
    * @return object Response
    */
-  static public function post($url, $params = array()) {
+  public static function post($url, $params = array()) {
 
     $defaults = array(
       'method' => 'POST'
@@ -240,7 +240,7 @@ class Remote {
    * @param array $params
    * @return object Response
    */
-  static public function put($url, $params = array()) {
+  public static function put($url, $params = array()) {
 
     $defaults = array(
       'method' => 'PUT'
@@ -258,7 +258,7 @@ class Remote {
    * @param array $params
    * @return object Response
    */
-  static public function delete($url, $params = array()) {
+  public static function delete($url, $params = array()) {
 
     $defaults = array(
       'method' => 'DELETE'
@@ -276,7 +276,7 @@ class Remote {
    * @param array $params
    * @return object Response
    */
-  static public function head($url, $params = array()) {
+  public static function head($url, $params = array()) {
 
     $defaults = array(
       'method' => 'HEAD'
@@ -295,7 +295,7 @@ class Remote {
    * @param array $params
    * @return array
    */
-  static public function headers($url, $params = array()) {
+  public static function headers($url, $params = array()) {
     $request = static::head($url, $params);
     return array_merge($request->headers(), $request->info());
   }

--- a/lib/response.php
+++ b/lib/response.php
@@ -36,9 +36,9 @@ class Response {
     $this->code    = $code;
 
     // convert arrays to json
-    if(is_array($this->content) and $this->format == 'json') {
+    if(is_array($this->content) && $this->format == 'json') {
 
-      if(defined('JSON_PRETTY_PRINT') and get('pretty')) {
+      if(defined('JSON_PRETTY_PRINT') && get('pretty')) {
         $this->content = json_encode($this->content, JSON_PRETTY_PRINT);
       } else {
         $this->content = json_encode($this->content);

--- a/lib/router.php
+++ b/lib/router.php
@@ -81,8 +81,10 @@ class Router {
   /**
    * Adds a new route
    *
-   * @param object $route
-   * @return object
+   * @param mixed $pattern
+   * @param mixed $params
+   * @param mixed $optional
+   * @return Obj
    */
   public function register($pattern, $params = array(), $optional = array()) {
 
@@ -241,7 +243,7 @@ class Router {
   /**
    * Translate route URI wildcards into regular expressions.
    *
-   * @param  string  $uri
+   * @param  string  $pattern
    * @return string
    */
   protected function wildcards($pattern) {

--- a/lib/router.php
+++ b/lib/router.php
@@ -168,7 +168,7 @@ class Router {
    */
   protected function filterer($filters) {
     foreach((array)$filters as $filter) {
-      if(array_key_exists($filter, $this->filters) and is_callable($this->filters[$filter])) {
+      if(array_key_exists($filter, $this->filters) && is_callable($this->filters[$filter])) {
         call_user_func($this->filters[$filter]);
       }
     }
@@ -205,8 +205,8 @@ class Router {
 
     foreach($routes as $route) {
 
-      if($route->https and !$https) continue;
-      if($route->ajax  and !$ajax)  continue;
+      if($route->https && !$https) continue;
+      if($route->ajax  && !$ajax)  continue;
 
       // handle exact matches
       if($route->pattern == $path) {
@@ -232,7 +232,7 @@ class Router {
 
     }
 
-    if($this->route and $this->filterer($this->route->filter) !== false) {
+    if($this->route && $this->filterer($this->route->filter) !== false) {
       return $this->route;
     } else {
       return null;

--- a/lib/s.php
+++ b/lib/s.php
@@ -14,14 +14,14 @@
  */
 class S {
 
-  static protected $started = false;
+  protected static $started = false;
 
   /**
    * Returns the current session id
    * 
    * @return string
    */  
-  static public function id() {
+  public static function id() {
     static::start();
     return session_id();
   }
@@ -46,7 +46,7 @@ class S {
    * @param  mixed   $key The key to define
    * @param  mixed   $value The value for the passed key
    */    
-  static public function set($key, $value = false) {
+  public static function set($key, $value = false) {
 
     static::start();
 
@@ -76,7 +76,7 @@ class S {
    * @param  mixed    $default Optional default value, which should be returned if no element has been found
    * @return mixed
    */  
-  static public function get($key = false, $default = null) {
+  public static function get($key = false, $default = null) {
 
     static::start();
 
@@ -93,7 +93,7 @@ class S {
    * @param mixed $default
    * @return mixed
    */
-  static public function pull($key, $default = null) {
+  public static function pull($key, $default = null) {
     $value = s::get($key, $default); 
     s::remove($key);
     return $value;
@@ -119,7 +119,7 @@ class S {
    * @param  mixed    $key The key to remove by
    * @return array    The session array without the value
    */  
-  static public function remove($key) {
+  public static function remove($key) {
 
     static::start();
 
@@ -139,7 +139,7 @@ class S {
    * </code>
    * 
    */  
-  static public function start() {
+  public static function start() {
     if(static::$started) return true;
     session_start();
     static::$started = true;
@@ -159,7 +159,7 @@ class S {
    * </code>
    *
    */  
-  static public function destroy() {
+  public static function destroy() {
     if(static::$started) {
       session_destroy();
       unset($_SESSION);
@@ -170,14 +170,14 @@ class S {
   /**
    * Alternative for s::destroy()
    */
-  static public function stop() {
+  public static function stop() {
     s::destroy();
   }
 
   /**
    * Destroys a session first and then starts it again
    */  
-  static public function restart() {
+  public static function restart() {
     static::destroy();
     static::start();
   }
@@ -185,7 +185,7 @@ class S {
   /**
    * Create a new session Id
    */
-  static public function regenerateId() {
+  public static function regenerateId() {
     static::start();
     session_regenerate_id();      
   }

--- a/lib/s.php
+++ b/lib/s.php
@@ -14,7 +14,101 @@
  */
 class S {
 
-  protected static $started = false;
+  public static $started = false;
+  public static $name    = 'kirby_session';
+  public static $timeout = 30;
+  public static $cookie  = array();
+
+  /**
+   * Starts a new session
+   *
+   * <code>
+   * 
+   * s::start();
+   * // do whatever you want with the session now
+   * 
+   * </code>
+   * 
+   */  
+  public static function start() {
+
+    if(session_status() === PHP_SESSION_ACTIVE) return true;
+
+    // store the session name
+    static::$cookie += array(
+      'lifetime' => 0,
+      'path'     => ini_get('session.cookie_path'),
+      'domain'   => ini_get('session.cookie_domain'),
+      'secure'   => r::secure(),
+      'httponly' => true      
+    );
+
+    // set the custom session name
+    session_name(static::$name); 
+
+    // make sure to use cookies only
+    ini_set('session.use_cookies', 1);
+    ini_set('session.use_only_cookies', 1);
+
+    // try to start the session
+    if(!session_start()) return false;
+
+    if(!setcookie(
+      static::$name, 
+      session_id(), 
+      cookie::lifetime(static::$cookie['lifetime']), 
+      static::$cookie['path'], 
+      static::$cookie['domain'], 
+      static::$cookie['secure'], 
+      static::$cookie['httponly']
+    )) {
+      return false;
+    }
+
+    // mark it as started
+    static::$started = true;      
+
+    // check if the session is still valid
+    if(!static::check()) {
+      return static::destroy();
+    }
+      
+    return true;
+
+  }
+
+  /**
+   * Checks if the session is still valid
+   * and not expired
+   * 
+   * @return boolean
+   */
+  public static function check() {
+
+    // check for the last activity and compare it with the session timeout
+    if(isset($_SESSION['kirby_session_activity']) && time() - $_SESSION['kirby_session_activity'] > static::$timeout * 60) {
+      return false;      
+    }
+
+    // check for an existing fingerprint and compare it
+    if(isset($_SESSION['kirby_session_fingerprint']) and $_SESSION['kirby_session_fingerprint'] !== static::fingerprint()) {
+      return false;
+    } 
+    
+    // store a new fingerprint and the last activity
+    $_SESSION['kirby_session_fingerprint'] = static::fingerprint();      
+    $_SESSION['kirby_session_activity']    = time();
+
+    return true;
+
+  }
+
+  /**
+   * Generates a fingerprint from the user agent string
+   */
+  public static function fingerprint() {
+    return sha1($_SERVER['HTTP_USER_AGENT'] . (ip2long($_SERVER['REMOTE_ADDR']) & ip2long('255.255.0.0')));
+  }
 
   /**
    * Returns the current session id
@@ -78,7 +172,7 @@ class S {
    */  
   public static function get($key = false, $default = null) {
 
-    static::start();
+    static::start(static::$name, static::$timeout, static::$cookie);
 
     if(!isset($_SESSION)) return false;
     if(empty($key)) return $_SESSION;
@@ -129,20 +223,12 @@ class S {
   }
 
   /**
-   * Starts a new session
-   *
-   * <code>
+   * Checks if the session has already been started
    * 
-   * s::start();
-   * // do whatever you want with the session now
-   * 
-   * </code>
-   * 
-   */  
-  public static function start() {
-    if(static::$started) return true;
-    session_start();
-    static::$started = true;
+   * @return boolean
+   */
+  public static function started() {
+    return static::$started;
   }
 
   /**
@@ -160,11 +246,17 @@ class S {
    *
    */  
   public static function destroy() {
-    if(static::$started) {
-      session_destroy();
-      unset($_SESSION);
-      static::$started = false;
-    }
+
+    if(!static::$started) return false;
+
+    $_SESSION = array();
+
+    cookie::remove(static::$name);
+
+    static::$started = false;
+
+    return session_destroy();
+
   }
 
   /**
@@ -186,8 +278,8 @@ class S {
    * Create a new session Id
    */
   public static function regenerateId() {
-    static::start();
-    session_regenerate_id();      
+    static::start(static::$name, static::$timeout, static::$cookie);
+    session_regenerate_id(true);      
   }
 
 }

--- a/lib/s.php
+++ b/lib/s.php
@@ -105,9 +105,15 @@ class S {
 
   /**
    * Generates a fingerprint from the user agent string
+   * 
+   * @return string
    */
   public static function fingerprint() {
-    return sha1($_SERVER['HTTP_USER_AGENT'] . (ip2long($_SERVER['REMOTE_ADDR']) & ip2long('255.255.0.0')));
+    if(!r::cli()) {
+      return sha1($_SERVER['HTTP_USER_AGENT'] . (ip2long($_SERVER['REMOTE_ADDR']) & ip2long('255.255.0.0')));      
+    } else {
+      return '';
+    }
   }
 
   /**

--- a/lib/s.php
+++ b/lib/s.php
@@ -87,6 +87,19 @@ class S {
   }
 
   /**
+   * Retrieves an item and removes it afterwards
+   * 
+   * @param string $key
+   * @param mixed $default
+   * @return mixed
+   */
+  static public function pull($key, $default = null) {
+    $value = s::get($key, $default); 
+    s::remove($key);
+    return $value;
+  }
+
+  /**
    * Removes a value from the session by key
    * 
    * <code>

--- a/lib/s.php
+++ b/lib/s.php
@@ -187,7 +187,7 @@ class S {
    */
   static public function regenerateId() {
     static::start();
-    @session_regenerate_id();      
+    session_regenerate_id();      
   }
 
 }

--- a/lib/server.php
+++ b/lib/server.php
@@ -32,14 +32,14 @@ class Server {
    * @param  mixed    $default Optional default value, which should be returned if no element has been found
    * @return mixed
    */  
-  static public function get($key = false, $default = null) {
+  public static function get($key = false, $default = null) {
     if(empty($key)) return $_SERVER;
     $key   = str::upper($key);
     $value = a::get($_SERVER, $key, $default);
     return static::sanitize($key, $value);
   }
 
-  static public function sanitize($key, $value) {
+  public static function sanitize($key, $value) {
 
     switch($key) {
       case 'SERVER_ADDR':

--- a/lib/silo.php
+++ b/lib/silo.php
@@ -15,9 +15,9 @@
  */
 class Silo {
 
-  static public $data = array();
+  public static $data = array();
 
-  static public function set($key, $value = null) {
+  public static function set($key, $value = null) {
     if(is_array($key)) {
       return static::$data = array_merge(static::$data, $key);
     } else {
@@ -25,12 +25,12 @@ class Silo {
     }
   }
 
-  static public function get($key = null, $default = null) {
+  public static function get($key = null, $default = null) {
     if(empty($key)) return static::$data;
     return isset(static::$data[$key]) ? static::$data[$key] : $default;
   }
 
-  static public function remove($key = null) {
+  public static function remove($key = null) {
     // reset the entire array
     if(is_null($key)) return static::$data = array();
     // unset a single key

--- a/lib/sql.php
+++ b/lib/sql.php
@@ -234,7 +234,6 @@ class Sql {
    * @todo  add more options per column
    * @param string $table The table name
    * @param array $columns
-   * @param string $type mysql or sqlite
    * @return string
    */
   public function createTable($table, $columns = array()) {

--- a/lib/sql.php
+++ b/lib/sql.php
@@ -288,7 +288,7 @@ class Sql {
       $output[] = trim(str::template($template[$type], array(
         'column.name'    => $name,
         'column.null'    => r(a::get($column, 'null') === false, 'NOT NULL', 'NULL'),
-        'column.key'     => r($key and $key != 'INDEX', $key, false),
+        'column.key'     => r($key && $key != 'INDEX', $key, false),
         'column.default' => r(!is_null($defaultValue), 'DEFAULT ' . $defaultValue),
       )));
 

--- a/lib/str.php
+++ b/lib/str.php
@@ -197,7 +197,7 @@ class Str {
    *
    * @param  string  $string
    * @param  string  $mode
-   * @return string
+   * @return mixed
    */
   static public function parse($string, $mode = 'json') {
 
@@ -248,7 +248,7 @@ class Str {
    *
    * </code>
    *
-   * @param string $href The url for the a tag
+   * @param string $email The url for the a tag
    * @param mixed $text The optional text. If null, the url will be used as text
    * @param array $attr Additional attributes for the tag
    * @return string the generated html
@@ -323,7 +323,7 @@ class Str {
    * </code>
    *
    * @param  string  $string The string to be shortened
-   * @param  int     $chars The final number of characters the string should have
+   * @param  int     $length The final number of characters the string should have
    * @param  string  $rep The element, which should be added if the string is too long. Ellipsis is the default.
    * @return string  The shortened string
    */
@@ -378,7 +378,7 @@ class Str {
    * @return string
    */
   static public function substr($str, $start, $length = null) {
-    return MB ? mb_substr($str, $start, $length == null ? static::length($str) : $length, 'UTF-8') : substr($str, $start, $length);
+    return MB ? mb_substr($str, $start, $length === null ? static::length($str) : $length, 'UTF-8') : substr($str, $start, $length);
   }
 
   /**
@@ -448,7 +448,7 @@ class Str {
   /**
    * Convert a string to a safe version to be used in a URL
    *
-   * @param  string  $text The unsafe string
+   * @param  string  $string The unsafe string
    * @param  string  $separator To be used instead of space and other non-word characters.
    * @return string  The safe string
    */
@@ -578,7 +578,7 @@ class Str {
    * which replaces tags like {mytag} with any other string
    *
    * @param  string $string
-   * @param  array  $replace An associative array with keys, which should be replaced and values.
+   * @param  array  $data An associative array with keys, which should be replaced and values.
    * @return string
    */
   static public function template($string, $data = array()) {

--- a/lib/str.php
+++ b/lib/str.php
@@ -201,24 +201,19 @@ class Str {
    */
   static public function parse($string, $mode = 'json') {
 
-    if(is_array($string) or is_object($string)) return $string;
+    if(is_array($string) || is_object($string)) return $string;
 
     switch($mode) {
       case 'json':
         return (array)@json_decode($string, true);
-        break;
       case 'xml':
         return xml::parse($string);
-        break;
       case 'url':
         return (array)@parse_url($string);
-        break;
       case 'php':
         return @unserialize($string);
-        break;
       default:
         return $string;
-        break;
     }
 
   }
@@ -459,7 +454,7 @@ class Str {
     $string = static::ascii($string);
 
     // replace spaces with simple dashes
-    $string = preg_replace('![^' . $allowed . ']!i','-', $string);
+    $string = preg_replace('![^' . $allowed . ']!i', $separator, $string);
     // remove double dashes
     $string = preg_replace('![-]{2,}!','-', $string);
     // trim trailing and leading dashes
@@ -492,7 +487,7 @@ class Str {
 
     foreach($parts AS $p) {
       $p = trim($p);
-      if(static::length($p) > 0 and static::length($p) >= $length) $out[] = $p;
+      if(static::length($p) > 0 && static::length($p) >= $length) $out[] = $p;
     }
 
     return $out;
@@ -625,7 +620,7 @@ class Str {
    * @return boolean
    */
   static public function startsWith($string, $needle) {
-    return $needle === '' or strpos($string, $needle) === 0;
+    return $needle === '' || strpos($string, $needle) === 0;
   }
 
   /**
@@ -636,7 +631,7 @@ class Str {
    * @return boolean
    */
   static public function endsWith($string, $needle) {
-    return $needle === '' or static::substr($string, -static::length($needle)) === $needle;
+    return $needle === '' || static::substr($string, -static::length($needle)) === $needle;
   }
 
   /**

--- a/lib/str.php
+++ b/lib/str.php
@@ -456,11 +456,11 @@ class Str {
     // replace spaces with simple dashes
     $string = preg_replace('![^' . $allowed . ']!i', $separator, $string);
     // remove double dashes
-    $string = preg_replace('![-]{2,}!','-', $string);
+    $string = preg_replace('![' . preg_quote($separator) . ']{2,}!', $separator, $string);
     // trim trailing and leading dashes
-    $string = trim($string, '-');
+    $string = trim($string, $separator);
     // replace slashes with dashes
-    $string = str_replace('/', '-', $string);
+    $string = str_replace('/', $separator, $string);
 
     return $string;
 

--- a/lib/str.php
+++ b/lib/str.php
@@ -14,7 +14,7 @@
  */
 class Str {
 
-  static public $ascii = array(
+  public static $ascii = array(
     '/Ä/' => 'Ae',
     '/æ|ǽ|ä/' => 'ae',
     '/œ|ö/' => 'oe',
@@ -108,7 +108,7 @@ class Str {
    * @param  boolean $keepTags True: lets stuff inside html tags untouched.
    * @return string  The html string
    */
-  static public function html($string, $keepTags = true) {
+  public static function html($string, $keepTags = true) {
     return html::encode($string, $keepTags);
   }
 
@@ -125,7 +125,7 @@ class Str {
    * @param  string  $string
    * @return string  The html string
    */
-  static public function unhtml($string) {
+  public static function unhtml($string) {
     return html::decode($string);
   }
 
@@ -145,7 +145,7 @@ class Str {
    * @param  boolean $html True: convert to html first
    * @return string
    */
-  static public function xml($text, $html = true) {
+  public static function xml($text, $html = true) {
     return xml::encode($text, $html);
   }
 
@@ -164,7 +164,7 @@ class Str {
    * @param  string  $string
    * @return string
    */
-  static public function unxml($string) {
+  public static function unxml($string) {
     return xml::decode($string);
   }
 
@@ -199,7 +199,7 @@ class Str {
    * @param  string  $mode
    * @return mixed
    */
-  static public function parse($string, $mode = 'json') {
+  public static function parse($string, $mode = 'json') {
 
     if(is_array($string) || is_object($string)) return $string;
 
@@ -224,7 +224,7 @@ class Str {
    * @param  string  $string
    * @return string
    */
-  static public function encode($string) {
+  public static function encode($string) {
     $string  = (string)$string;
     $encoded = '';
     for($i=0; $i < static::length($string); $i++) {
@@ -248,7 +248,7 @@ class Str {
    * @param array $attr Additional attributes for the tag
    * @return string the generated html
    */
-  static public function email($email, $text = false, $attr = array()) {
+  public static function email($email, $text = false, $attr = array()) {
     return html::email($email, $text, $attr);
   }
 
@@ -260,7 +260,7 @@ class Str {
    * @param array $attr Additional attributes for the tag
    * @return string the generated html
    */
-  static public function link($href, $text = null, $attr = array()) {
+  public static function link($href, $text = null, $attr = array()) {
     return html::a($href, $text, $attr);
   }
 
@@ -269,7 +269,7 @@ class Str {
    *
    * @param string $string
    */
-  static public function words($string) {
+  public static function words($string) {
     preg_match_all('/(\pL{4,})/iu', $string, $m);
     return array_shift($m);
   }
@@ -280,7 +280,7 @@ class Str {
    * @param string $string
    * @return string
    */
-  static public function sentences($string) {
+  public static function sentences($string) {
     return preg_split('/(?<=[.?!])\s+/', $string, -1, PREG_SPLIT_NO_EMPTY);
   }
 
@@ -290,7 +290,7 @@ class Str {
    * @param string $string
    * @return array
    */
-  static public function lines($string) {
+  public static function lines($string) {
     return str::split($string, PHP_EOL);
   }
 
@@ -300,7 +300,7 @@ class Str {
    * @param string $string
    * @return boolean
    */
-  static public function isURL($string) {
+  public static function isURL($string) {
     return filter_var($string, FILTER_VALIDATE_URL);
   }
 
@@ -322,7 +322,7 @@ class Str {
    * @param  string  $rep The element, which should be added if the string is too long. Ellipsis is the default.
    * @return string  The shortened string
    */
-  static public function short($string, $length, $rep = '…') {
+  public static function short($string, $length, $rep = '…') {
     if(!$length) return $string;
     if(static::length($string) <= $length) return $string;
     $string = static::substr($string, 0, $length);
@@ -339,7 +339,7 @@ class Str {
    * @param  string  $rep The element, which should be added if the string is too long. Ellipsis is the default.
    * @return string  The shortened string
    */
-  static public function excerpt($string, $chars = 140, $removehtml = true, $rep='…') {
+  public static function excerpt($string, $chars = 140, $removehtml = true, $rep='…') {
     if($removehtml) $string = strip_tags($string);
     $string = str_replace(PHP_EOL, ' ', trim($string));
     if(static::length($string) <= $chars) return $string;
@@ -354,7 +354,7 @@ class Str {
    * @param string $string
    * @return string
    */
-  static public function widont($string = '') {
+  public static function widont($string = '') {
     return preg_replace_callback('|([^\s])\s+([^\s]+)\s*$|', function($matches) {
       if(str::contains($matches[2], '-')) {
         return $matches[1] . ' ' . str_replace('-', '&#8209;', $matches[2]);
@@ -372,7 +372,7 @@ class Str {
    * @param  int     $length
    * @return string
    */
-  static public function substr($str, $start, $length = null) {
+  public static function substr($str, $start, $length = null) {
     return MB ? mb_substr($str, $start, $length === null ? static::length($str) : $length, 'UTF-8') : substr($str, $start, $length);
   }
 
@@ -382,7 +382,7 @@ class Str {
    * @param  string  $str
    * @return string
    */
-  static public function lower($str) {
+  public static function lower($str) {
     return MB ? mb_strtolower($str, 'UTF-8') : strtolower($str);
   }
 
@@ -392,7 +392,7 @@ class Str {
    * @param  string  $str
    * @return string
    */
-  static public function upper($str) {
+  public static function upper($str) {
     return MB ? mb_strtoupper($str, 'UTF-8') : strtoupper($str);
   }
 
@@ -402,7 +402,7 @@ class Str {
    * @param  string  $str
    * @return string
    */
-  static public function length($str) {
+  public static function length($str) {
     return MB ? mb_strlen($str, 'UTF-8') : strlen($str);
   }
 
@@ -414,7 +414,7 @@ class Str {
    * @param  boolean $i ignore upper/lowercase
    * @return string
    */
-  static public function contains($str, $needle, $i = true) {
+  public static function contains($str, $needle, $i = true) {
     if($i) {
       $str    = static::lower($str);
       $needle = static::lower($needle);
@@ -428,7 +428,7 @@ class Str {
    * @param  int  $length The length of the random string
    * @return string
    */
-  static public function random($length = false, $type = 'alphaNum') {
+  public static function random($length = false, $type = 'alphaNum') {
     $length = $length ? $length : rand(5,10);
     $pool   = static::pool($type);
     shuffle($pool);
@@ -447,7 +447,7 @@ class Str {
    * @param  string  $separator To be used instead of space and other non-word characters.
    * @return string  The safe string
    */
-  static public function slug($string, $separator = '-', $allowed = 'a-z0-9') {
+  public static function slug($string, $separator = '-', $allowed = 'a-z0-9') {
 
     $string = trim($string);
     $string = static::lower($string);
@@ -477,7 +477,7 @@ class Str {
    * @param  int     $length The min length of values.
    * @return array   An array of found values
    */
-  static public function split($string, $separator = ',', $length = 1) {
+  public static function split($string, $separator = ',', $length = 1) {
 
     if(is_array($string)) return $string;
 
@@ -500,7 +500,7 @@ class Str {
    * @param  string  $string
    * @return string
    */
-  static public function ucwords($string) {
+  public static function ucwords($string) {
     return MB ? mb_convert_case($string, MB_CASE_TITLE, 'UTF-8') : ucwords(strtolower($string));
   }
 
@@ -510,7 +510,7 @@ class Str {
    * @param  string $string
    * @return string
    */
-  static public function ucfirst($string) {
+  public static function ucfirst($string) {
     return static::upper(static::substr($string, 0, 1)) . static::lower(static::substr($string, 1));
   }
 
@@ -520,7 +520,7 @@ class Str {
    * @param string $string
    * @return string
    */
-  static public function encoding($string) {
+  public static function encoding($string) {
 
     if(MB) {
       return mb_detect_encoding($string, 'UTF-8, ISO-8859-1, windows-1251');
@@ -541,7 +541,7 @@ class Str {
    * @param string $sourceEncoding (optional)
    * @return string
    */
-  static public function convert($string, $targetEncoding, $sourceEncoding = null) {
+  public static function convert($string, $targetEncoding, $sourceEncoding = null) {
     // detect the source encoding if not passed as third argument
     if(is_null($sourceEncoding)) $sourceEncoding = static::encoding($string);
     return iconv($sourceEncoding, $targetEncoding, $string);
@@ -553,7 +553,7 @@ class Str {
    * @param  string  $string
    * @return string
    */
-  static public function utf8($string) {
+  public static function utf8($string) {
     return static::convert($string, 'utf-8');
   }
 
@@ -563,7 +563,7 @@ class Str {
    * @param  string  $string
    * @return string
    */
-  static public function stripslashes($string) {
+  public static function stripslashes($string) {
     if(is_array($string)) return $string;
     return get_magic_quotes_gpc() ? stripslashes($string) : $string;
   }
@@ -576,7 +576,7 @@ class Str {
    * @param  array  $data An associative array with keys, which should be replaced and values.
    * @return string
    */
-  static public function template($string, $data = array()) {
+  public static function template($string, $data = array()) {
     $replace = array();
     foreach($data as $key => $value) $replace['{' . $key . '}'] = $value;
     return str_replace(array_keys($replace), array_values($replace), $string);
@@ -588,7 +588,7 @@ class Str {
    * @param  string  $string
    * @return string
    */
-  static public function ascii($string) {
+  public static function ascii($string) {
     $foreign = static::$ascii;
     $string  = preg_replace(array_keys($foreign), array_values($foreign), $string);
     return preg_replace('/[^\x09\x0A\x0D\x20-\x7E]/', '', $string);
@@ -600,7 +600,7 @@ class Str {
    * @param string $string
    * @param string $name Optional name for the downloaded file
    */
-  static public function download($string, $name = null) {
+  public static function download($string, $name = null) {
 
     header::download(array(
       'name' => $name ? $name : 'text.txt',
@@ -619,7 +619,7 @@ class Str {
    * @param string $needle
    * @return boolean
    */
-  static public function startsWith($string, $needle) {
+  public static function startsWith($string, $needle) {
     return $needle === '' || strpos($string, $needle) === 0;
   }
 
@@ -630,7 +630,7 @@ class Str {
    * @param string $needle
    * @return boolean
    */
-  static public function endsWith($string, $needle) {
+  public static function endsWith($string, $needle) {
     return $needle === '' || static::substr($string, -static::length($needle)) === $needle;
   }
 
@@ -641,7 +641,7 @@ class Str {
    * @param  boolean $array
    * @return string
    */
-  static public function pool($type, $array = true) {
+  public static function pool($type, $array = true) {
 
     $pool = array();
 

--- a/lib/system.php
+++ b/lib/system.php
@@ -55,29 +55,28 @@ class System {
     }
 
     // if this is actually a file, we don't need to search for it any longer
-    if(file_exists($command)) return (is_executable($command))? realpath($command) : false;
+    if(file_exists($command)) {
+      return is_executable($command) ? realpath($command) : false;
+    }
 
     // let the shell search for it
     // depends on the operating system
-    $exists = false; // does the command exist?
-    $result = '';    // where is it located?
-    if (strtolower(substr(PHP_OS, 0, 3)) === 'win') {
+    if(strtolower(substr(PHP_OS, 0, 3)) === 'win') {
       // Windows
       // run the "where" command
       $result = `where $command`;
-
       // everything besides "Could not find files" would be OK
       $exists = !preg_match('/Could not find files/', $result);
     } else {
       // Unix
       // run the "which" command
       $result = `which $command`;
-
       // an empty output means there is no path
       $exists = !empty($result);
     }
 
-    return ($exists)? trim($result) : false;
+    return $exists ? trim($result) : false;
+
   }
 
   /**

--- a/lib/system.php
+++ b/lib/system.php
@@ -19,7 +19,7 @@ class System {
    * @return boolean
    */
   static public function available() {
-    return !ini_get('safe_mode') and function_exists('exec');
+    return (!ini_get('safe_mode') && function_exists('exec'));
   }
 
   /**

--- a/lib/system.php
+++ b/lib/system.php
@@ -18,7 +18,7 @@ class System {
    *
    * @return boolean
    */
-  static public function available() {
+  public static function available() {
     return (!ini_get('safe_mode') && function_exists('exec'));
   }
 
@@ -28,7 +28,7 @@ class System {
    * @param  string  $command Name or path of the command to check
    * @return boolean
    */
-  static public function isExecutable($command) {
+  public static function isExecutable($command) {
     // check if everything we need is available
     if(!static::available()) {
       throw new Exception('The exec() function is not available on this system. Probably, safe_mode is on (shame!).');
@@ -48,7 +48,7 @@ class System {
    * @param  string  $command Name or path of the command
    * @return mixed
    */
-  static public function realpath($command) {
+  public static function realpath($command) {
     // check if everything we need is available
     if(!static::available()) {
       throw new Exception('The exec() function is not available on this system. Probably, safe_mode is on (shame!).');
@@ -87,7 +87,7 @@ class System {
    * @param  string  $what What to return ('status', 'success', 'output' or 'all')
    * @return mixed
    */
-  static public function execute($command, $arguments = array(), $what = 'all') {
+  public static function execute($command, $arguments = array(), $what = 'all') {
     // check if everything we need is available
     if(!static::available()) {
       throw new Exception('The exec() function is not available on this system. Probably, safe_mode is on (shame!).');
@@ -143,7 +143,7 @@ class System {
    * @param  string  $arguments Additional arguments
    * @return array
    */
-  static public function __callStatic($command, $arguments) {
+  public static function __callStatic($command, $arguments) {
     return static::execute($command, $arguments, 'all');
   }
 

--- a/lib/thumb.php
+++ b/lib/thumb.php
@@ -104,7 +104,7 @@ class Thumb extends Obj {
         'safeFilename' => $safeName . '.' . $this->extension(),
         'width'        => $this->options['width'],
         'height'       => $this->options['height'],
-        'hash'         => md5($this->source->root() . $this->settingsIdentifier()),
+        'hash'         => md5(str_replace(kirby()->roots()->index(), null, $this->source()->root()) . $this->settingsIdentifier()),
       ));
 
       $destination->url  = $this->options['url'] . '/' . $destination->filename;

--- a/lib/thumb.php
+++ b/lib/thumb.php
@@ -14,9 +14,9 @@ class Thumb extends Obj {
   const ERROR_INVALID_IMAGE  = 0;
   const ERROR_INVALID_DRIVER = 1;
 
-  static public $drivers = array();
+  public static $drivers = array();
 
-  static public $defaults = array(
+  public static $defaults = array(
     'destination' => false,
     'filename'    => '{safeName}-{hash}.{extension}',
     'url'         => '/thumbs',

--- a/lib/thumb.php
+++ b/lib/thumb.php
@@ -60,7 +60,7 @@ class Thumb extends Obj {
     if(!$this->isThere()) {
 
       // check for a valid image
-      if(!$this->source->exists() or $this->source->type() != 'image') {
+      if(!$this->source->exists() || $this->source->type() != 'image') {
         throw new Error('The given image is invalid', static::ERROR_INVALID_IMAGE);
       }
 
@@ -184,7 +184,7 @@ class Thumb extends Obj {
 
     // if the thumb already exists and the source hasn't been updated
     // we don't need to generate a new thumbnail
-    if(file_exists($this->destination->root) and f::modified($this->destination->root) >= $this->source->modified()) return true;
+    if(file_exists($this->destination->root) && f::modified($this->destination->root) >= $this->source->modified()) return true;
 
     return false;
 
@@ -201,10 +201,10 @@ class Thumb extends Obj {
     if($this->options['overwrite'] === true) return false;
 
     // try to use the original if resizing is not necessary
-    if($this->options['width']   >= $this->source->width()  and
-       $this->options['height']  >= $this->source->height() and
-       $this->options['crop']    == false                   and
-       $this->options['blur']    == false                   and
+    if($this->options['width']   >= $this->source->width()  &&
+       $this->options['height']  >= $this->source->height() &&
+       $this->options['crop']    == false                   &&
+       $this->options['blur']    == false                   &&
        $this->options['upscale'] == false) return true;
 
     return false;

--- a/lib/timer.php
+++ b/lib/timer.php
@@ -13,12 +13,12 @@ class Timer {
 
   public static $time = null;
 
-  static function start() {
+  static public function start() {
     $time = explode(' ', microtime());
     static::$time = (double)$time[1] + (double)$time[0];
   }
 
-  static function stop() {
+  static public function stop() {
     $time  = explode(' ', microtime());
     $time  = (double)$time[1] + (double)$time[0];
     $timer = static::$time;

--- a/lib/timer.php
+++ b/lib/timer.php
@@ -13,12 +13,12 @@ class Timer {
 
   public static $time = null;
 
-  static public function start() {
+  public static function start() {
     $time = explode(' ', microtime());
     static::$time = (double)$time[1] + (double)$time[0];
   }
 
-  static public function stop() {
+  public static function stop() {
     $time  = explode(' ', microtime());
     $time  = (double)$time[1] + (double)$time[0];
     $timer = static::$time;

--- a/lib/toolkit.php
+++ b/lib/toolkit.php
@@ -11,7 +11,7 @@
  */
 class Toolkit {
 
-  public static $version = '2.1.1';
+  public static $version = '2.2.0';
 
   public static function version() {
     return static::$version;

--- a/lib/toolkit.php
+++ b/lib/toolkit.php
@@ -11,9 +11,9 @@
  */
 class Toolkit {
 
-  static public $version = '2.1.1';
+  public static $version = '2.1.1';
 
-  static public function version() {
+  public static function version() {
     return static::$version;
   }
 

--- a/lib/tpl.php
+++ b/lib/tpl.php
@@ -13,9 +13,9 @@
  */
 class Tpl extends Silo {
 
-  static public $data = array();
+  public static $data = array();
 
-  static public function load($_file, $_data = array(), $_return = true) {
+  public static function load($_file, $_data = array(), $_return = true) {
     if(!file_exists($_file)) return false;
     ob_start();
     extract(array_merge(static::$data, (array)$_data));

--- a/lib/upload.php
+++ b/lib/upload.php
@@ -59,7 +59,7 @@ class Upload {
     // which will lead to overwritten duplicates. 
     // this dirty hack will simply add a uniqid between the 
     // name and the extension to avoid duplicates
-    if($source and f::name($source['name']) == 'image' and detect::ios()) {
+    if($source && f::name($source['name']) == 'image' && detect::ios()) {
       $source['name'] = 'image-' . uniqid() . '.' . ltrim(f::extension($source['name']), '.');
     }
 
@@ -100,7 +100,7 @@ class Upload {
 
     $source = $this->source();
 
-    if(is_null($source['name']) or is_null($source['tmp_name'])) {
+    if(is_null($source['name']) || is_null($source['tmp_name'])) {
       throw new Error('The file has not been found', static::ERROR_MISSING_FILE);
     }
 
@@ -108,7 +108,7 @@ class Upload {
       throw new Error('The upload failed', static::ERROR_FAILED_UPLOAD);
     }
 
-    if(file_exists($this->to()) and $this->options['overwrite'] === false) {
+    if(file_exists($this->to()) && $this->options['overwrite'] === false) {
       throw new Error('The file exists and cannot be overwritten', static::ERROR_UNALLOWED_OVERWRITE);
     }
 

--- a/lib/url.php
+++ b/lib/url.php
@@ -20,9 +20,9 @@ class Url {
   static public function scheme($url = null) {
     if(is_null($url)) {      
       if(
-        (isset($_SERVER['HTTPS']) and !empty($_SERVER['HTTPS']) and strtolower($_SERVER['HTTPS']) != 'off') or
-        server::get('SERVER_PORT')            == '443' or 
-        server::get('HTTP_X_FORWARDED_PORT')  == '443' or 
+        (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) != 'off') ||
+        server::get('SERVER_PORT')            == '443' || 
+        server::get('HTTP_X_FORWARDED_PORT')  == '443' || 
         server::get('HTTP_X_FORWARDED_PROTO') == 'https'
       ) {
         return 'https';
@@ -235,7 +235,7 @@ class Url {
    */
   static public function isAbsolute($url) {
     // don't convert absolute urls
-    return (str::startsWith($url, 'http://') or str::startsWith($url, 'https://') or str::startsWith($url, '//'));
+    return (str::startsWith($url, 'http://') || str::startsWith($url, 'https://') || str::startsWith($url, '//'));
   }
 
   /**

--- a/lib/url.php
+++ b/lib/url.php
@@ -13,11 +13,11 @@
  */
 class Url {
 
-  static public $home    = '/';
-  static public $to      = null;
-  static public $current = null;
+  public static $home    = '/';
+  public static $to      = null;
+  public static $current = null;
 
-  static public function scheme($url = null) {
+  public static function scheme($url = null) {
     if(is_null($url)) {      
       if(
         (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) != 'off') ||
@@ -39,7 +39,7 @@ class Url {
    *
    * @return string
    */
-  static public function current() {
+  public static function current() {
     if(!is_null(static::$current)) return static::$current;
     return static::$current = static::base() . server::get('REQUEST_URI');
   }
@@ -49,13 +49,13 @@ class Url {
    *
    * @return string
    */
-  static public function currentDir() {
+  public static function currentDir() {
     return dirname(static::current());
   }
 
   /**
    */
-  static public function host($url = null) {
+  public static function host($url = null) {
     if(is_null($url)) $url = static::current();
     return parse_url($url, PHP_URL_HOST);
   }
@@ -65,7 +65,7 @@ class Url {
    *
    * @return mixed
    */
-  static public function port($url = null) {
+  public static function port($url = null) {
     if(is_null($url)) $url = static::current();
     $port = intval(parse_url($url, PHP_URL_PORT));
     return v::between($port, 1, 65535) ? $port : false;
@@ -74,7 +74,7 @@ class Url {
   /**
    * Returns only the cleaned path of the url
    */
-  static public function path($url = null) {
+  public static function path($url = null) {
 
     if(is_null($url)) $url = static::current();
 
@@ -89,7 +89,7 @@ class Url {
   /**
    * Returns the params in the url
    */
-  static public function params($url = null) {
+  public static function params($url = null) {
     if(is_null($url)) $url = static::current();
     $path = static::path($url);
     if(empty($path)) return array();
@@ -105,7 +105,7 @@ class Url {
   /**
    * Returns the path without params
    */
-  static public function fragments($url = null) {
+  public static function fragments($url = null) {
     if(is_null($url)) $url = static::current();
     $path = static::path($url);
     if(empty($path)) return null;
@@ -119,7 +119,7 @@ class Url {
   /**
    * Returns the query as array
    */
-  static public function query($url = null) {
+  public static function query($url = null) {
     if(is_null($url)) $url = static::current();
     parse_str(parse_url($url, PHP_URL_QUERY), $array);
     return $array;
@@ -128,19 +128,19 @@ class Url {
   /**
    * Checks if the url contains a query string
    */
-  static public function hasQuery($url = null) {
+  public static function hasQuery($url = null) {
     if(is_null($url)) $url = static::current();
     return str::contains($url, '?');
   }
 
   /**
    */
-  static public function hash($url = null) {
+  public static function hash($url = null) {
     if(is_null($url)) $url = static::current();
     return parse_url($url, PHP_URL_FRAGMENT);
   }
 
-  static public function build($parts = array(), $url = null) {
+  public static function build($parts = array(), $url = null) {
 
     if(is_null($url)) $url = static::current();
 
@@ -165,29 +165,29 @@ class Url {
 
   }
 
-  static public function queryToString($query = null) {
+  public static function queryToString($query = null) {
     if(is_null($query)) $query = url::query();
     return http_build_query($query);
   }
 
-  static public function paramsToString($params = null) {
+  public static function paramsToString($params = null) {
     if(is_null($params)) $params = url::params();
     $result = array();
     foreach($params as $key => $val) $result[] = $key . ':' . $val;
     return implode('/', $result);
   }
 
-  static public function stripPath($url = null) {
+  public static function stripPath($url = null) {
     if(is_null($url)) $url = static::current();
     return static::build(array('fragments' => array(), 'params' => array()), $url);
   }
 
-  static public function stripFragments($url = null) {
+  public static function stripFragments($url = null) {
     if(is_null($url)) $url = static::current();
     return static::build(array('fragments' => array()), $url);
   }
 
-  static public function stripParams($url = null) {
+  public static function stripParams($url = null) {
     if(is_null($url)) $url = static::current();
     return static::build(array('params' => array()), $url);
   }
@@ -205,7 +205,7 @@ class Url {
    * @param  string  $url
    * @return string
    */
-  static public function stripQuery($url = null) {
+  public static function stripQuery($url = null) {
     if(is_null($url)) $url = static::current();
     return static::build(array('query' => array()), $url);
   }
@@ -223,7 +223,7 @@ class Url {
    * @param  string  $url
    * @return string
    */
-  static public function stripHash($url) {
+  public static function stripHash($url) {
     if(is_null($url)) $url = static::current();
     return static::build(array('hash' => ''), $url);
   }
@@ -233,7 +233,7 @@ class Url {
    *
    * @return boolean
    */
-  static public function isAbsolute($url) {
+  public static function isAbsolute($url) {
     // don't convert absolute urls
     return (str::startsWith($url, 'http://') || str::startsWith($url, 'https://') || str::startsWith($url, '//'));
   }
@@ -245,7 +245,7 @@ class Url {
    * @param string $home
    * @return string
    */
-  static public function makeAbsolute($path, $home = null) {
+  public static function makeAbsolute($path, $home = null) {
 
     if(static::isAbsolute($path)) return $path;
 
@@ -265,7 +265,7 @@ class Url {
    * @param string $url
    * @return string
    */
-  static public function fix($url) {
+  public static function fix($url) {
     // make sure to not touch absolute urls
     return (!preg_match('!^(https|http|ftp)\:\/\/!i', $url)) ? 'http://' . $url : $url;
   }
@@ -275,7 +275,7 @@ class Url {
    *
    * @return string
    */
-  static public function home() {
+  public static function home() {
     return static::$home;
   }
 
@@ -284,7 +284,7 @@ class Url {
    *
    * @return string
    */
-  static public function to() {
+  public static function to() {
     return call_user_func_array(static::$to, func_get_args());
   }
 
@@ -293,7 +293,7 @@ class Url {
    *
    * @return string
    */
-  static public function last() {
+  public static function last() {
     return r::referer();
   }
 
@@ -303,7 +303,7 @@ class Url {
    * @param string $url
    * @return string
    */
-  static public function base($url = null) {
+  public static function base($url = null) {
     if(is_null($url)) {
       $port = server::get('SERVER_PORT');
       $port = in_array($port, array(80, 443)) ? null : $port;
@@ -333,7 +333,7 @@ class Url {
    * @param  string  $rep The element, which should be added if the string is too long. Ellipsis is the default.
    * @return string  The shortened URL
    */
-  static public function short($url, $length = false, $base = false, $rep = '…') {
+  public static function short($url, $length = false, $base = false, $rep = '…') {
 
     if($base) $url = static::base($url);
 
@@ -353,7 +353,7 @@ class Url {
    * 
    * @return string
    */
-  static public function index() {
+  public static function index() {
     if(r::cli()) {
       return '/';
     } else {

--- a/lib/url.php
+++ b/lib/url.php
@@ -67,7 +67,8 @@ class Url {
    */
   static public function port($url = null) {
     if(is_null($url)) $url = static::current();
-    return parse_url($url, PHP_URL_PORT);
+    $port = intval(parse_url($url, PHP_URL_PORT));
+    return v::between($port, 1, 65535) ? $port : false;
   }
 
   /**
@@ -310,7 +311,7 @@ class Url {
     } else {
       $port   = static::port($url);
       $scheme = static::scheme($url);
-      $host   = static::host($url) . r($port, ':' . $port);
+      $host   = static::host($url) . r(is_int($port), ':' . $port);
       return r($scheme, $scheme . '://') . $host;      
     }
   }
@@ -327,7 +328,7 @@ class Url {
    * </code>
    *
    * @param  string  $url The URL to be shortened
-   * @param  int     $chars The final number of characters the URL should have
+   * @param  int     $length The final number of characters the URL should have
    * @param  boolean $base True: only take the base of the URL.
    * @param  string  $rep The element, which should be added if the string is too long. Ellipsis is the default.
    * @return string  The shortened URL

--- a/lib/v.php
+++ b/lib/v.php
@@ -15,14 +15,14 @@
 class V {
 
   // an array with all installed validators
-  static public $validators = array();
+  public static $validators = array();
 
   /**
    * Return the list of all validators
    *
    * @return array
    */
-  static public function validators() {
+  public static function validators() {
     return static::$validators;
   }
 
@@ -33,7 +33,7 @@ class V {
    * @param array $arguments
    * @return boolean
    */
-  static public function __callStatic($method, $arguments) {
+  public static function __callStatic($method, $arguments) {
 
     // check for missing validators
     if(!isset(static::$validators[$method])) throw new Exception('The validator does not exist: ' . $method);

--- a/lib/v.php
+++ b/lib/v.php
@@ -59,7 +59,7 @@ v::$validators = array(
     return v::match($value, '/^[a-z0-9]+$/i');
   },
   'between' => function($value, $min, $max) {
-    return v::min($value, $min) and v::max($value, $max);
+    return v::min($value, $min) && v::max($value, $max);
   },
   'date' => function($value) {
     $time = strtotime($value);
@@ -79,7 +79,7 @@ v::$validators = array(
     return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
   },
   'filename' => function($value) {
-    return v::match($value, '/^[a-z0-9@._-]+$/i') and v::min($value, 2);
+    return v::match($value, '/^[a-z0-9@._-]+$/i') && v::min($value, 2);
   },
   'in' => function($value, $in) {
     return in_array($value, $in, true);

--- a/lib/v.php
+++ b/lib/v.php
@@ -91,7 +91,7 @@ v::$validators = array(
     return filter_var($value, FILTER_VALIDATE_IP) !== false;
   },
   'match' => function($value, $preg) {
-    return preg_match($preg, $value) == true;
+    return preg_match($preg, $value) > 0;
   },
   'max' => function($value, $max) {
     return size($value) <= $max;

--- a/lib/visitor.php
+++ b/lib/visitor.php
@@ -14,17 +14,17 @@
 class Visitor {
 
   // banned ips
-  static public $banned = array();
+  public static $banned = array();
 
   // cache for the detected language code
-  static protected $acceptedLanguageCode = null;
+  protected static $acceptedLanguageCode = null;
 
   /**
    * Returns the ip address of the current visitor
    *
    * @return string
    */
-  static public function ip() {
+  public static function ip() {
     return getenv('REMOTE_ADDR');
   }
 
@@ -33,7 +33,7 @@ class Visitor {
    *
    * @return string
    */
-  static public function ua() {
+  public static function ua() {
     return isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : null;
   }
 
@@ -42,7 +42,7 @@ class Visitor {
    *
    * @return string
    */
-  static public function userAgent() {
+  public static function userAgent() {
     return static::ua();
   }
 
@@ -51,7 +51,7 @@ class Visitor {
    *
    * @return string
    */
-  static public function acceptedLanguage() {
+  public static function acceptedLanguage() {
     return isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : null;
   }
 
@@ -60,7 +60,7 @@ class Visitor {
    *
    * @return string
    */
-  static public function acceptedLanguageCode() {
+  public static function acceptedLanguageCode() {
     if(!is_null(static::$acceptedLanguageCode)) return static::$acceptedLanguageCode;
     $detected = explode(',', static::acceptedLanguage());
     $detected = explode('-', $detected[0]);
@@ -72,7 +72,7 @@ class Visitor {
    *
    * @return string
    */
-  static public function referrer() {
+  public static function referrer() {
     return r::referer();
   }
 
@@ -81,7 +81,7 @@ class Visitor {
    *
    * @return string
    */
-  static public function referer() {
+  public static function referer() {
     return r::referer();
   }
 
@@ -90,7 +90,7 @@ class Visitor {
    *
    * @return boolean
    */
-  static public function banned() {
+  public static function banned() {
     return in_array(static::ip(), static::$banned);
   }
 

--- a/lib/xml.php
+++ b/lib/xml.php
@@ -98,8 +98,8 @@ class Xml {
    * @param  int     $level   The indendation level
    * @return string  The XML string
    */
-  static function create($array, $tag = 'root', $head = true, $charset = 'utf-8', $tab = '  ', $level = 0) {
-    $result  = ($level == 0 and $head) ? '<?xml version="1.0" encoding="' . $charset . '"?>' . PHP_EOL : '';
+  static public function create($array, $tag = 'root', $head = true, $charset = 'utf-8', $tab = '  ', $level = 0) {
+    $result  = ($level == 0 && $head) ? '<?xml version="1.0" encoding="' . $charset . '"?>' . PHP_EOL : '';
     $nlevel  = ($level + 1);
     $result .= str_repeat($tab, $level) . '<' . $tag . '>' . PHP_EOL;
     foreach($array as $key => $value) {
@@ -115,7 +115,7 @@ class Xml {
           }
           $mtags = true;
         }
-        if(!$mtags and count($value) > 0) {
+        if(!$mtags && count($value) > 0) {
           $result .= static::create($value, $key, $head, $charset, $tab, $nlevel);
         }
       } elseif(trim($value) != '') {

--- a/lib/xml.php
+++ b/lib/xml.php
@@ -26,17 +26,19 @@ class Xml {
    *  
    * </code>
    *    
-   * @param  string  $text
+   * @param  string  $string
    * @param  boolean $html True: convert to html first
    * @return string
    */  
   static public function encode($string, $html = true) {
 
     // convert raw text to html safe text
-    if($html) $text = html::encode($string, false);
+    if($html) {
+      $string = html::encode($string, false);
+    }
 
     // convert html entities to xml entities
-    return strtr($text, html::entities());
+    return strtr($string, html::entities());
 
   }
 

--- a/lib/xml.php
+++ b/lib/xml.php
@@ -30,7 +30,7 @@ class Xml {
    * @param  boolean $html True: convert to html first
    * @return string
    */  
-  static public function encode($string, $html = true) {
+  public static function encode($string, $html = true) {
 
     // convert raw text to html safe text
     if($html) {
@@ -57,7 +57,7 @@ class Xml {
    * @param  string  $string
    * @return string
    */  
-  static public function decode($string) {
+  public static function decode($string) {
     // convert xml entities to html entities
     $string = strtr($string, static::entities());
     return html::decode($string);
@@ -69,7 +69,7 @@ class Xml {
    * @param  string  $xml
    * @return mixed
    */
-  static public function parse($xml) {
+  public static function parse($xml) {
 
     $xml = preg_replace('/(<\/?)(\w+):([^>]*>)/', '$1$2$3', $xml);
     $xml = @simplexml_load_string($xml, null, LIBXML_NOENT);
@@ -84,7 +84,7 @@ class Xml {
    * 
    * @return array
    */
-  static public function entities() {
+  public static function entities() {
     return array_flip(html::entities());    
   }
 
@@ -98,7 +98,7 @@ class Xml {
    * @param  int     $level   The indendation level
    * @return string  The XML string
    */
-  static public function create($array, $tag = 'root', $head = true, $charset = 'utf-8', $tab = '  ', $level = 0) {
+  public static function create($array, $tag = 'root', $head = true, $charset = 'utf-8', $tab = '  ', $level = 0) {
     $result  = ($level == 0 && $head) ? '<?xml version="1.0" encoding="' . $charset . '"?>' . PHP_EOL : '';
     $nlevel  = ($level + 1);
     $result .= str_repeat($tab, $level) . '<' . $tag . '>' . PHP_EOL;

--- a/lib/yaml.php
+++ b/lib/yaml.php
@@ -19,7 +19,7 @@ class Yaml {
    * @param array $array
    * @return string
    */
-  static public function encode($array) {
+  public static function encode($array) {
     return preg_replace('!^---\n!', '', spyc::yamldump($array));
   }
 
@@ -30,7 +30,7 @@ class Yaml {
    * @param array $array
    * @return boolean
    */
-  static public function write($file, $array) {
+  public static function write($file, $array) {
     return f::write($file, static::encode($array));
   }
 
@@ -40,7 +40,7 @@ class Yaml {
    * @param string $yaml
    * @return array
    */
-  static public function decode($yaml) {
+  public static function decode($yaml) {
     return spyc::yamlload($yaml);
   }
 
@@ -50,7 +50,7 @@ class Yaml {
    * @param string $file
    * @return array
    */
-  static public function read($file) {
+  public static function read($file) {
     return spyc::yamlload($file);
   }
 

--- a/test/DirTest.php
+++ b/test/DirTest.php
@@ -49,7 +49,7 @@ class DirTest extends PHPUnit_Framework_TestCase {
     f::write($this->tmpDir . DS . 'testfile-3.txt', str::random(5));
 
     $this->assertEquals(15, dir::size($this->tmpDir));
-    $this->assertEquals('15 b', dir::niceSize($this->tmpDir));
+    $this->assertEquals('15 B', dir::niceSize($this->tmpDir));
 
     dir::remove($this->tmpDir);
 

--- a/test/FTest.php
+++ b/test/FTest.php
@@ -70,8 +70,8 @@ class FTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testNiceSize() {
-    $this->assertEquals('37 b', f::niceSize($this->contentFile));
-    $this->assertEquals('37 b', f::niceSize(37));
+    $this->assertEquals('37 B', f::niceSize($this->contentFile));
+    $this->assertEquals('37 B', f::niceSize(37));
   }
 
   public function testModified() {

--- a/test/MediaTest.php
+++ b/test/MediaTest.php
@@ -66,7 +66,7 @@ class MediaTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testNiceSize() {
-    $this->assertEquals('428 b', $this->media->niceSize());        
+    $this->assertEquals('428 B', $this->media->niceSize());        
   }
 
   public function testMime() {

--- a/vendors/abeautifulsite/SimpleImage.php
+++ b/vendors/abeautifulsite/SimpleImage.php
@@ -41,7 +41,7 @@ class SimpleImage {
      * @throws Exception
      *
      */
-    function __construct($filename = null, $width = null, $height = null, $color = null) {
+    public function __construct($filename = null, $width = null, $height = null, $color = null) {
         if ($filename !== null) {
             $this->load($filename);
         } elseif ($width !== null) {
@@ -53,7 +53,7 @@ class SimpleImage {
      * Destroy image resource
      *
      */
-    function __destruct() {
+    public function __destruct() {
         if( get_resource_type($this->image) === 'gd' ) {
             imagedestroy($this->image);
         }
@@ -72,7 +72,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function adaptive_resize($width, $height = null) {
+    public function adaptive_resize($width, $height = null) {
 
         return $this->thumbnail($width, $height);
 
@@ -84,7 +84,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function auto_orient() {
+    public function auto_orient() {
 		
 	// stop if there's no exif data
 	if(!isset($this->original_info['exif']['Orientation'])) {
@@ -142,7 +142,7 @@ class SimpleImage {
      * @return  SimpleImage
      *
      */
-    function best_fit($max_width, $max_height) {
+    public function best_fit($max_width, $max_height) {
 
         // If it already fits, there's nothing to do
         if ($this->width <= $max_width && $this->height <= $max_height) {
@@ -180,7 +180,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function blur($type = 'selective', $passes = 1) {
+    public function blur($type = 'selective', $passes = 1) {
         switch (strtolower($type)) {
             case 'gaussian':
                 $type = IMG_FILTER_GAUSSIAN_BLUR;
@@ -203,7 +203,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function brightness($level) {
+    public function brightness($level) {
         imagefilter($this->image, IMG_FILTER_BRIGHTNESS, $this->keep_within($level, -255, 255));
         return $this;
     }
@@ -217,7 +217,7 @@ class SimpleImage {
      *
      *
      */
-    function contrast($level) {
+    public function contrast($level) {
         imagefilter($this->image, IMG_FILTER_CONTRAST, $this->keep_within($level, -100, 100));
         return $this;
     }
@@ -232,7 +232,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function colorize($color, $opacity) {
+    public function colorize($color, $opacity) {
         $rgba = $this->normalize_color($color);
         $alpha = $this->keep_within(127 - (127 * $opacity), 0, 127);
         imagefilter($this->image, IMG_FILTER_COLORIZE, $this->keep_within($rgba['r'], 0, 255), $this->keep_within($rgba['g'], 0, 255), $this->keep_within($rgba['b'], 0, 255), $alpha);
@@ -250,7 +250,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function create($width, $height = null, $color = null) {
+    public function create($width, $height = null, $color = null) {
 
         $height = $height ?: $width;
         $this->width = $width;
@@ -284,7 +284,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function crop($x1, $y1, $x2, $y2) {
+    public function crop($x1, $y1, $x2, $y2) {
 
         // Determine crop size
         if ($x2 < $x1) {
@@ -319,7 +319,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function desaturate($percentage = 100) {
+    public function desaturate($percentage = 100) {
 
         // Determine percentage
         $percentage = $this->keep_within($percentage, 0, 100);
@@ -349,7 +349,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function edges() {
+    public function edges() {
         imagefilter($this->image, IMG_FILTER_EDGEDETECT);
         return $this;
     }
@@ -360,7 +360,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function emboss() {
+    public function emboss() {
         imagefilter($this->image, IMG_FILTER_EMBOSS);
         return $this;
     }
@@ -374,7 +374,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function fill($color = '#000000') {
+    public function fill($color = '#000000') {
 
         $rgba = $this->normalize_color($color);
         $fill_color = imagecolorallocatealpha($this->image, $rgba['r'], $rgba['g'], $rgba['b'], $rgba['a']);
@@ -394,7 +394,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function fit_to_height($height) {
+    public function fit_to_height($height) {
 
         $aspect_ratio = $this->height / $this->width;
         $width = $height / $aspect_ratio;
@@ -411,7 +411,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function fit_to_width($width) {
+    public function fit_to_width($width) {
 
         $aspect_ratio = $this->height / $this->width;
         $height = $width * $aspect_ratio;
@@ -428,7 +428,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function flip($direction) {
+    public function flip($direction) {
 
         $new = imagecreatetruecolor($this->width, $this->height);
         imagealphablending($new, false);
@@ -459,7 +459,7 @@ class SimpleImage {
      * @return int
      *
      */
-    function get_height() {
+    public function get_height() {
         return $this->height;
     }
 
@@ -469,7 +469,7 @@ class SimpleImage {
      * @return string   portrait|landscape|square
      *
      */
-    function get_orientation() {
+    public function get_orientation() {
 
         if (imagesx($this->image) > imagesy($this->image)) {
             return 'landscape';
@@ -496,7 +496,7 @@ class SimpleImage {
      * )</pre>
      *
      */
-    function get_original_info() {
+    public function get_original_info() {
         return $this->original_info;
     }
 
@@ -506,7 +506,7 @@ class SimpleImage {
      * @return int
      *
      */
-    function get_width() {
+    public function get_width() {
         return $this->width;
     }
 
@@ -516,7 +516,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function invert() {
+    public function invert() {
         imagefilter($this->image, IMG_FILTER_NEGATE);
         return $this;
     }
@@ -530,7 +530,7 @@ class SimpleImage {
      * @throws Exception
      *
      */
-    function load($filename) {
+    public function load($filename) {
 
         // Require GD library
         if (!extension_loaded('gd')) {
@@ -548,7 +548,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function load_base64($base64string) {
+    public function load_base64($base64string) {
         if (!extension_loaded('gd')) {
             throw new Exception('Required extension GD is not loaded.');
         }
@@ -564,7 +564,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function mean_remove() {
+    public function mean_remove() {
         imagefilter($this->image, IMG_FILTER_MEAN_REMOVAL);
         return $this;
     }
@@ -577,7 +577,7 @@ class SimpleImage {
      * @throws Exception
      *
      */
-    function opacity($opacity) {
+    public function opacity($opacity) {
 
         // Determine opacity
         $opacity = $this->keep_within($opacity, 0, 1) * 100;
@@ -608,7 +608,7 @@ class SimpleImage {
      * @throws Exception
      *
      */
-    function output($format = null, $quality = null) {
+    public function output($format = null, $quality = null) {
 
         // Determine quality
         $quality = $quality ?: $this->quality;
@@ -647,7 +647,6 @@ class SimpleImage {
                 break;
             default:
                 throw new Exception('Unsupported image format: '.$this->filename);
-                break;
         }
     }
 
@@ -661,7 +660,7 @@ class SimpleImage {
      * @throws Exception
      *
      */
-    function output_base64($format = null, $quality = null) {
+    public function output_base64($format = null, $quality = null) {
 
         // Determine quality
         $quality = $quality ?: $this->quality;
@@ -700,7 +699,6 @@ class SimpleImage {
                 break;
             default:
                 throw new Exception('Unsupported image format: '.$this->filename);
-                break;
         }
         $image_data = ob_get_contents();
         ob_end_clean();
@@ -724,7 +722,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function overlay($overlay, $position = 'center', $opacity = 1, $x_offset = 0, $y_offset = 0) {
+    public function overlay($overlay, $position = 'center', $opacity = 1, $x_offset = 0, $y_offset = 0) {
 
         // Load overlay image
         if( !($overlay instanceof SimpleImage) ) {
@@ -790,7 +788,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function pixelate($block_size = 10) {
+    public function pixelate($block_size = 10) {
         imagefilter($this->image, IMG_FILTER_PIXELATE, $block_size, true);
         return $this;
     }
@@ -804,7 +802,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function resize($width, $height) {
+    public function resize($width, $height) {
 
         // Generate new GD image
         $new = imagecreatetruecolor($width, $height);
@@ -847,7 +845,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function rotate($angle, $bg_color = '#000000') {
+    public function rotate($angle, $bg_color = '#000000') {
 
         // Perform the rotation
         $rgba = $this->normalize_color($bg_color);
@@ -878,7 +876,7 @@ class SimpleImage {
      * @throws Exception
      *
      */
-    function save($filename = null, $quality = null, $format = null) {
+    public function save($filename = null, $quality = null, $format = null) {
 
         // Determine quality, filename, and format
         $quality = $quality ?: $this->quality;
@@ -918,7 +916,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function sepia() {
+    public function sepia() {
         imagefilter($this->image, IMG_FILTER_GRAYSCALE);
         imagefilter($this->image, IMG_FILTER_COLORIZE, 100, 50, 0);
         return $this;
@@ -930,7 +928,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function sketch() {
+    public function sketch() {
         imagefilter($this->image, IMG_FILTER_MEAN_REMOVAL);
         return $this;
     }
@@ -943,7 +941,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function smooth($level) {
+    public function smooth($level) {
         imagefilter($this->image, IMG_FILTER_SMOOTH, $this->keep_within($level, -10, 10));
         return $this;
     }
@@ -963,7 +961,7 @@ class SimpleImage {
      * @throws Exception
      *
      */
-    function text($text, $font_file, $font_size = 12, $color = '#000000', $position = 'center', $x_offset = 0, $y_offset = 0) {
+    public function text($text, $font_file, $font_size = 12, $color = '#000000', $position = 'center', $x_offset = 0, $y_offset = 0) {
 
         // todo - this method could be improved to support the text angle
         $angle = 0;
@@ -1042,7 +1040,7 @@ class SimpleImage {
      * @return SimpleImage
      *
      */
-    function thumbnail($width, $height = null) {
+    public function thumbnail($width, $height = null) {
 
         // Determine height
         $height = $height ?: $width;
@@ -1107,7 +1105,6 @@ class SimpleImage {
                     break;
                 default:
                     throw new Exception('Invalid image: '.$this->filename);
-                    break;
             }
         } elseif (function_exists('getimagesizefromstring')) {
             $info = getimagesizefromstring($this->imagestring);

--- a/vendors/abeautifulsite/SimpleImage.php
+++ b/vendors/abeautifulsite/SimpleImage.php
@@ -26,7 +26,7 @@ class SimpleImage {
      */
     public $quality = 80;
 
-    protected $image, $filename, $original_info, $width, $height, $imagestring;
+    protected $image, $filename, $original_info, $width, $height, $imagestring, $exif;
 
     /**
      * Create instance and load an image, or create an image from scratch
@@ -38,17 +38,15 @@ class SimpleImage {
      *                                  Where red, green, blue - integers 0-255, alpha - integer 0-127<br>
      *                                  (is used for creating image from scratch)
      *
-     * @return SimpleImage
      * @throws Exception
      *
      */
     function __construct($filename = null, $width = null, $height = null, $color = null) {
-        if ($filename) {
+        if ($filename !== null) {
             $this->load($filename);
-        } elseif ($width) {
+        } elseif ($width !== null) {
             $this->create($width, $height, $color);
         }
-        return $this;
     }
 
     /**
@@ -267,7 +265,7 @@ class SimpleImage {
             'mime' => 'image/png'
         );
 
-        if ($color) {
+        if ($color !== null) {
             $this->fill($color);
         }
 
@@ -545,7 +543,7 @@ class SimpleImage {
     /**
      * Load a base64 string as image
      *
-     * @param string        $filename   base64 string
+     * @param string        $base64string   base64 string
      *
      * @return SimpleImage
      *
@@ -885,7 +883,7 @@ class SimpleImage {
         // Determine quality, filename, and format
         $quality = $quality ?: $this->quality;
         $filename = $filename ?: $this->filename;
-        if( !$format ) {
+        if( $format === null ) {
             $format = $this->file_ext($filename) ?: $this->original_info['format'];
         }
 
@@ -976,7 +974,7 @@ class SimpleImage {
 
         // Determine textbox size
         $box = imagettfbbox($font_size, $angle, $font_file, $text);
-        if (!$box) {
+        if (empty($box)) {
             throw new Exception('Unable to load font: '.$font_file);
         }
         $box_width = abs($box[6] - $box[2]);
@@ -1087,8 +1085,6 @@ class SimpleImage {
 
     /**
      * Get meta data of image or base64 string
-     *
-     * @param string|null       $imagestring    If omitted treat as a normal image
      *
      * @return SimpleImage
      * @throws Exception

--- a/vendors/yaml/yaml.php
+++ b/vendors/yaml/yaml.php
@@ -5,7 +5,7 @@
    * @version 0.5.1
    * @author Vlad Andersen <vlad.andersen@gmail.com>
    * @author Chris Wanstrath <chris@ozmm.org>
-   * @link http://code.google.com/p/spyc/
+   * @link https://github.com/mustangostang/spyc/
    * @copyright Copyright 2005-2006 Chris Wanstrath, 2006-2011 Vlad Andersen
    * @license http://www.opensource.org/licenses/mit-license.php MIT License
    * @package Spyc
@@ -30,6 +30,17 @@ if (!function_exists('spyc_load_file')) {
    */
   function spyc_load_file ($file) {
     return Spyc::YAMLLoad($file);
+  }
+}
+
+if (!function_exists('spyc_dump')) {
+  /**
+   * Dumps array to YAML.
+   * @param array $data Array.
+   * @return string
+   */
+  function spyc_dump ($data) {
+    return Spyc::YAMLDump($data, false, false, true);
   }
 }
 
@@ -184,10 +195,11 @@ class Spyc {
      * @param array $array PHP array
      * @param int $indent Pass in false to use the default, which is 2
      * @param int $wordwrap Pass in 0 for no wordwrap, false for default (40)
+     * @param int $no_opening_dashes Do not start YAML file with "---\n"
      */
-  public static function YAMLDump($array,$indent = false,$wordwrap = false) {
+  public static function YAMLDump($array, $indent = false, $wordwrap = false, $no_opening_dashes = false) {
     $spyc = new Spyc;
-    return $spyc->dump($array,$indent,$wordwrap);
+    return $spyc->dump($array, $indent, $wordwrap, $no_opening_dashes);
   }
 
 
@@ -211,7 +223,7 @@ class Spyc {
      * @param int $indent Pass in false to use the default, which is 2
      * @param int $wordwrap Pass in 0 for no wordwrap, false for default (40)
      */
-  public function dump($array,$indent = false,$wordwrap = false) {
+  public function dump($array,$indent = false,$wordwrap = false, $no_opening_dashes = false) {
     // Dumps to some very clean YAML.  We'll have to add some more features
     // and options soon.  And better support for folding.
 
@@ -229,7 +241,8 @@ class Spyc {
     }
 
     // New YAML document
-    $string = "---\n";
+    $string = "";
+    if (!$no_opening_dashes) $string = "---\n";
 
     // Start at the base of the array and move through it.
     if ($array) {
@@ -303,7 +316,7 @@ class Spyc {
   private function _dumpNode($key, $value, $indent, $previous_key = -1, $first_key = 0, $source_array = null) {
     // do some folding here, for blocks
     if (is_string ($value) && ((strpos($value,"\n") !== false || strpos($value,": ") !== false || strpos($value,"- ") !== false ||
-      strpos($value,"*") !== false || strpos($value,"#") !== false || strpos($value,"<") !== false || strpos($value,">") !== false || strpos ($value, '  ') !== false ||
+      strpos($value,"*") !== false || strpos($value,"#") !== false || strpos($value,"<") !== false || strpos($value,">") !== false || strpos ($value, '%') !== false || strpos ($value, '  ') !== false ||
       strpos($value,"[") !== false || strpos($value,"]") !== false || strpos($value,"{") !== false || strpos($value,"}") !== false) || strpos($value,"&") !== false || strpos($value, "'") !== false || strpos($value, "!") === 0 ||
       substr ($value, -1, 1) == ':')
     ) {
@@ -313,14 +326,15 @@ class Spyc {
     }
 
     if ($value === array()) $value = '[ ]';
-    if (in_array ($value, array ('true', 'TRUE', 'false', 'FALSE', 'y', 'Y', 'n', 'N', 'null', 'NULL'), true)) {
-       $value = $this->_doLiteralBlock($value,$indent);
+    if ($value === "") $value = '""';
+    if (self::isTranslationWord($value)) {
+      $value = $this->_doLiteralBlock($value, $indent);
     }
     if (trim ($value) != $value)
        $value = $this->_doLiteralBlock($value,$indent);
 
     if (is_bool($value)) {
-       $value = ($value) ? "true" : "false";
+       $value = $value ? "true" : "false";
     }
 
     if ($value === null) $value = 'null';
@@ -358,9 +372,17 @@ class Spyc {
     }
     $exploded = explode("\n",$value);
     $newValue = '|';
-    $indent  += $this->_dumpIndent;
+    if (isset($exploded[0]) && ($exploded[0] == "|" || $exploded[0] == "|-" || $exploded[0] == ">")) {
+        $newValue = $exploded[0];
+        unset($exploded[0]);
+    }
+    $indent += $this->_dumpIndent;
     $spaces   = str_repeat(' ',$indent);
     foreach ($exploded as $line) {
+      $line = trim($line);
+      if (strpos($line, '"') === 0 && strrpos($line, '"') == (strlen($line)-1) || strpos($line, "'") === 0 && strrpos($line, "'") == (strlen($line)-1)) {
+        $line = substr($line, 1, -1);
+      }
       $newValue .= "\n" . $spaces . ($line);
     }
     return $newValue;
@@ -383,10 +405,66 @@ class Spyc {
     } else {
       if ($this->setting_dump_force_quotes && is_string ($value) && $value !== self::REMPTY)
         $value = '"' . $value . '"';
+      if (is_numeric($value) && is_string($value))
+        $value = '"' . $value . '"';
     }
 
 
     return $value;
+  }
+
+  private function isTrueWord($value) {
+    $words = self::getTranslations(array('true', 'on', 'yes', 'y'));
+    return in_array($value, $words, true);
+  }
+
+  private function isFalseWord($value) {
+    $words = self::getTranslations(array('false', 'off', 'no', 'n'));
+    return in_array($value, $words, true);
+  }
+
+  private function isNullWord($value) {
+    $words = self::getTranslations(array('null', '~'));
+    return in_array($value, $words, true);
+  }
+
+  private function isTranslationWord($value) {
+    return (
+      self::isTrueWord($value)  ||
+      self::isFalseWord($value) ||
+      self::isNullWord($value)
+    );
+  }
+
+  /**
+     * Coerce a string into a native type
+     * Reference: http://yaml.org/type/bool.html
+     * TODO: Use only words from the YAML spec.
+     * @access private
+     * @param $value The value to coerce
+     */
+  private function coerceValue(&$value) {
+    if (self::isTrueWord($value)) {
+      $value = true;
+    } else if (self::isFalseWord($value)) {
+      $value = false;
+    } else if (self::isNullWord($value)) {
+      $value = null;
+    }
+  }
+
+  /**
+     * Given a set of words, perform the appropriate translations on them to
+     * match the YAML 1.1 specification for type coercing.
+     * @param $words The words to translate
+     * @access private
+     */
+  private static function getTranslations(array $words) {
+    $result = array();
+    foreach ($words as $i) {
+      $result = array_merge($result, array(ucfirst($i), strtoupper($i), strtolower($i)));
+    }
+    return $result;
   }
 
 // LOADING FUNCTIONS
@@ -404,7 +482,7 @@ class Spyc {
   private function loadWithSource($Source) {
     if (empty ($Source)) return array();
     if ($this->setting_use_syck_is_possible && function_exists ('syck_load')) {
-      $array = syck_load (implode ('', $Source));
+      $array = syck_load (implode ("\n", $Source));
       return is_array($array) ? $array : array();
     }
 
@@ -426,7 +504,7 @@ class Spyc {
       if ($literalBlockStyle) {
         $line = rtrim ($line, $literalBlockStyle . " \n");
         $literalBlock = '';
-        $line .= $this->LiteralPlaceHolder;
+        $line .= ' '.$this->LiteralPlaceHolder;
         $literal_block_indent = strlen($Source[$i+1]) - strlen(ltrim($Source[$i+1]));
         while (++$i < $cnt && $this->literalBlockContinues($Source[$i], $this->indent)) {
           $literalBlock = $this->addLiteralLine($literalBlock, $Source[$i], $literalBlockStyle, $literal_block_indent);
@@ -462,7 +540,7 @@ class Spyc {
 
   private function loadFromSource ($input) {
     if (!empty($input) && strpos($input, "\n") === false && file_exists($input))
-    return file($input);
+      $input = file_get_contents($input);
 
     return $this->loadFromString($input);
   }
@@ -518,7 +596,7 @@ class Spyc {
      * @return mixed
      */
   private function _toType($value) {
-    if ($value === '') return null;
+    if ($value === '') return "";
     $first_character = $value[0];
     $last_character = substr($value, -1, 1);
 
@@ -530,13 +608,13 @@ class Spyc {
       $is_quoted = true;
     } while (0);
 
-    if ($is_quoted)
+    if ($is_quoted) {
+      $value = str_replace('\n', "\n", $value);
       return strtr(substr ($value, 1, -1), array ('\\"' => '"', '\'\'' => '\'', '\\\'' => '\''));
+    }
 
     if (strpos($value, ' #') !== false && !$is_quoted)
       $value = preg_replace('/\s+#(.+)$/','',$value);
-
-    if (!$is_quoted) $value = str_replace('\n', "\n", $value);
 
     if ($first_character == '[' && $last_character == ']') {
       // Take out strings sequences and mappings
@@ -590,15 +668,12 @@ class Spyc {
       return $value;
     }
 
-    if (in_array($value,
-                 array('true', 'on', '+', 'yes', 'y', 'True', 'TRUE', 'On', 'ON', 'YES', 'Yes', 'Y'))) {
-      return true;
+    if (is_numeric($value) && preg_match('/^0[xX][0-9a-fA-F]+$/', $value)) {
+      // Hexadecimal value.
+      return hexdec($value);
     }
 
-    if (in_array(strtolower($value),
-                 array('false', 'off', '-', 'no', 'n'))) {
-      return false;
-    }
+    $this->coerceValue($value);
 
     if (is_numeric($value)) {
       if ($value === '0') return 0;
@@ -624,6 +699,15 @@ class Spyc {
     $seqs = array();
     $maps = array();
     $saved_strings = array();
+    $saved_empties = array();
+
+    // Check for empty strings
+    $regex = '/("")|(\'\')/';
+    if (preg_match_all($regex,$inline,$strings)) {
+      $saved_empties = $strings[0];
+      $inline  = preg_replace($regex,'YAMLEmpty',$inline);
+    }
+    unset($regex);
 
     // Check for strings
     $regex = '/(?:(")|(?:\'))((?(1)[^"]+|[^\']+))(?(1)"|\')/';
@@ -632,6 +716,8 @@ class Spyc {
       $inline  = preg_replace($regex,'YAMLString',$inline);
     }
     unset($regex);
+
+    // echo $inline;
 
     $i = 0;
     do {
@@ -695,6 +781,17 @@ class Spyc {
       }
     }
 
+
+    // Re-add the empties
+    if (!empty($saved_empties)) {
+      foreach ($explode as $key => $value) {
+        while (strpos($value,'YAMLEmpty') !== false) {
+          $explode[$key] = preg_replace('/YAMLEmpty/', '', $value, 1);
+          $value = $explode[$key];
+        }
+      }
+    }
+
     $finished = true;
     foreach ($explode as $key => $value) {
       if (strpos($value,'YAMLSeq') !== false) {
@@ -706,6 +803,9 @@ class Spyc {
       if (strpos($value,'YAMLString') !== false) {
         $finished = false; break;
       }
+      if (strpos($value,'YAMLEmpty') !== false) {
+        $finished = false; break;
+      }
     }
     if ($finished) break;
 
@@ -713,6 +813,7 @@ class Spyc {
     if ($i > 10)
       break; // Prevent infinite loops.
     }
+
 
     return $explode;
   }
@@ -911,8 +1012,8 @@ class Spyc {
 
 
   private function isArrayElement ($line) {
-    if (!$line) return false;
-    if ($line[0] != '-') return false;
+    if (!$line || !is_scalar($line)) return false;
+    if (substr($line, 0, 2) != '- ') return false;
     if (strlen ($line) > 3)
       if (substr($line,0,3) == '---') return false;
 
@@ -939,7 +1040,7 @@ class Spyc {
   }
 
   private function startsMappedSequence ($line) {
-    return ($line[0] == '-' && substr ($line, -1, 1) == ':');
+    return (substr($line, 0, 2) == '- ' && substr ($line, -1, 1) == ':');
   }
 
   private function returnMappedSequence ($line) {
@@ -950,7 +1051,16 @@ class Spyc {
     return array($array);
   }
 
+  private function checkKeysInValue($value) {
+    if (strchr('[{"\'', $value[0]) === false) {
+      if (strchr($value, ': ') !== false) {
+          throw new Exception('Too many keys: '.$value);
+      }
+    }
+  }
+
   private function returnMappedValue ($line) {
+    $this->checkKeysInValue($line);
     $array = array();
     $key         = self::unquote (trim(substr($line,0,-1)));
     $array[$key] = '';
@@ -972,7 +1082,7 @@ class Spyc {
   private function returnKeyValuePair ($line) {
     $array = array();
     $key = '';
-    if (strpos ($line, ':')) {
+    if (strpos ($line, ': ')) {
       // It's a key/value pair most likely
       // If the key is in double quotes pull it out
       if (($line[0] == '"' || $line[0] == "'") && preg_match('/^(["\'](.*)["\'](\s)*:)/',$line,$matches)) {
@@ -980,10 +1090,10 @@ class Spyc {
         $key   = $matches[2];
       } else {
         // Do some guesswork as to the key and the value
-        $explode = explode(':',$line);
-        $key     = trim($explode[0]);
-        array_shift($explode);
-        $value   = trim(implode(':',$explode));
+        $explode = explode(': ', $line);
+        $key     = trim(array_shift($explode));
+        $value   = trim(implode(': ', $explode));
+        $this->checkKeysInValue($value);
       }
       // Set the type of the value.  Int, string, etc
       $value = $this->_toType($value);
@@ -1002,6 +1112,9 @@ class Spyc {
      $array = array();
      $value   = trim(substr($line,1));
      $value   = $this->_toType($value);
+     if ($this->isArrayElement($value)) {
+       $value = $this->returnArrayElement($value);
+     }
      $array[] = $value;
      return $array;
   }


### PR DESCRIPTION
Make thumbnail hash independent of the site root and start at ‘/content’. This way you can move a Kirby installation around without having to regenerate all the thumbnails again.