### PR TITLE
Return collection if sortBy args are empty

### DIFF
--- a/lib/collection.php
+++ b/lib/collection.php
@@ -314,7 +314,7 @@ class Collection extends I {
     $array      = $collection->data;
     $params     = array();
 
-    if(empty($array) || empty(array_filter($args)) return $collection;
+    if(empty($array) || empty(array_filter($args))) return $collection;
 
     foreach($args as $i => $param) {
       if(is_string($param)) {

--- a/lib/collection.php
+++ b/lib/collection.php
@@ -314,7 +314,7 @@ class Collection extends I {
     $array      = $collection->data;
     $params     = array();
 
-    if(empty($array)) return $collection;
+    if(empty($array) || empty(array_filter($args)) return $collection;
 
     foreach($args as $i => $param) {
       if(is_string($param)) {

--- a/lib/collection.php
+++ b/lib/collection.php
@@ -313,8 +313,10 @@ class Collection extends I {
     $collection = clone $this;
     $array      = $collection->data;
     $params     = array();
+    
+    $args = array_filter($args);
 
-    if(empty($array) || empty(array_filter($args))) return $collection;
+    if(empty($array) || empty($args)) return $collection;
 
     foreach($args as $i => $param) {
       if(is_string($param)) {


### PR DESCRIPTION
Ran into an issue where for instance no sort parameters are passed by `$page->hasPrevVisible()` which resulted into the following error: `Warning: array_multisort(): Array sizes are inconsistent`.