### PR TITLE
Fix PHP 7 compatibility

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -315,7 +315,7 @@ class Database {
     }
 
     // fetch that stuff
-    $results = $this->statement->$options['method']();
+    $results = $this->statement->{$options['method']}();
 
     if($options['iterator'] == 'array') return $this->lastResult = $results;
     return $this->lastResult = new $options['iterator']($results);


### PR DESCRIPTION
Because of the syntax change, PHP 7 threw an "Array to string conversion" error. This change works for both PHP 5 and 7.