### PR TITLE
Enable email tag to use additional parameters without cluttering anchor text

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -218,9 +218,10 @@ class Html {
    * @return string the generated html
    */
   public static function email($email, $text = null, $attr = array()) {
+    /* show only the eMail address without additional parameters (if the 'text' argument is empty) */
+    if(empty($text)) $text = str::encode(strstr($email, '?', true));
     $email = str::encode($email);
     $attr  = array_merge(array('href' => 'mailto:' . $email), $attr);
-    if(empty($text)) $text = $email;
     return static::tag('a', $text, $attr);
   }
 


### PR DESCRIPTION
This modification enables the use of additional parameters (like subject) in the mailto email argument without displaying these in the anchor text (that is derived from the email argument if the 'text' argument is empty).

E.g. `(email: info@domain.com?subject=Website Contact)` now generates

`<a href="mailto:info@domain.com?subject=Website Contact">info@domain.com</a>` 

instead of
`<a href="mailto:info@domain.com?subject=Website Contact">info@domain.com?subject=Website Contact</a>`

This seems to be a much simpler alternative to the approach discussed in the forums:
https://forum.getkirby.com/t/kirbytext-email-with-subject/599