### PR TITLE
Mailto anchor improvement

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -218,9 +218,10 @@ class Html {
    * @return string the generated html
    */
   public static function email($email, $text = null, $attr = array()) {
+    /* show only the eMail address without additional parameters (if the 'text' argument is empty) */
+    if(empty($text)) $text = str::encode(strstr($email, '?', true));
     $email = str::encode($email);
     $attr  = array_merge(array('href' => 'mailto:' . $email), $attr);
-    if(empty($text)) $text = $email;
     return static::tag('a', $text, $attr);
   }
 

--- a/lib/html.php
+++ b/lib/html.php
@@ -219,7 +219,7 @@ class Html {
    */
   public static function email($email, $text = null, $attr = array()) {
     /* show only the eMail address without additional parameters (if the 'text' argument is empty) */
-    if(empty($text)) $text = str::encode(strstr($email, '?', true));
+    if(empty($text)) $text = str::encode(current(explode('?', $email)));
     $email = str::encode($email);
     $attr  = array_merge(array('href' => 'mailto:' . $email), $attr);
     return static::tag('a', $text, $attr);


### PR DESCRIPTION
@bastianallgeier: Just found out the hard way that yesterday's "improvement" to the eMail tag had a fatal flaw: the strstr() function returns 'false' instead of something useful if no additional parameters ('?subject=...') are present in the eMail address. Used an array split instead, which performed as expected in all my tests.

Sorry for this.