### PR TITLE
fix ssl setting with cloudflare

### DIFF
--- a/lib/url.php
+++ b/lib/url.php
@@ -23,7 +23,8 @@ class Url {
         (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) != 'off') ||
         server::get('SERVER_PORT')            == '443' || 
         server::get('HTTP_X_FORWARDED_PORT')  == '443' || 
-        server::get('HTTP_X_FORWARDED_PROTO') == 'https'
+        server::get('HTTP_X_FORWARDED_PROTO') == 'https' ||
+        server::get('HTTP_X_FORWARDED_PROTO') == 'https, http'
       ) {
         return 'https';
       } else {


### PR DESCRIPTION
[cloudflare](https://www.cloudflare.com/)’s proxy sends `https, http` as a `HTTP_X_FORWARDED_PROTO` value for ssl enabled sites. this will fix it for websites behind the service.