### PR TITLE
Fix SystemTest to work on more systems

### DIFF
--- a/test/SystemTest.php
+++ b/test/SystemTest.php
@@ -73,7 +73,7 @@ class SystemTest extends PHPUnit_Framework_TestCase {
   
   public function testRealpath() {
     // basic stuff
-    $this->assertEquals('/bin/bash', System::realpath('bash'));
+    $this->assertEquals('/bin/sh', System::realpath('sh'));
     $this->assertEquals(false, System::realpath('notexistingforsure'));
     
     // executable file


### PR DESCRIPTION
Checking for "bash" is not as reliable as it should be as some users/environments have another bash installed at /usr/bin/bash or /usr/local/bin/bash.