### PR TITLE
Add LIBXML_NOCDATA

### DIFF
--- a/lib/xml.php
+++ b/lib/xml.php
@@ -72,7 +72,7 @@ class Xml {
   public static function parse($xml) {
 
     $xml = preg_replace('/(<\/?)(\w+):([^>]*>)/', '$1$2$3', $xml);
-    $xml = @simplexml_load_string($xml, null, LIBXML_NOENT);
+    $xml = @simplexml_load_string($xml, null, LIBXML_NOENT | LIBXML_NOCDATA);
     $xml = @json_encode($xml);
     $xml = @json_decode($xml, true);
     return (is_array($xml)) ? $xml : false;


### PR DESCRIPTION
Add `LIBXML_NOCDATA` to `simplexml_load_string` in `parse` to preserve data wrapped in `<![CDATA[]]>`.