### PR TITLE
Refactor database classes

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -165,6 +165,7 @@ class Database {
 
   /**
    * Escapes a value to be used for a safe query
+   * NOTE: Prepared statements using bound parameters are more secure and solid
    *
    * @param string $value
    * @return string

--- a/lib/database.php
+++ b/lib/database.php
@@ -117,6 +117,7 @@ class Database {
     // try to connect
     $this->connection = new PDO($this->dsn, $options['user'], $options['password']);
     $this->connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $this->connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 
     // store the connection
     static::$connections[$this->id] = $this;
@@ -357,7 +358,9 @@ class Database {
     $queries = str::split($query, ';');
 
     foreach($queries as $query) {
-      if(!$this->execute($query)) return false;
+      $query = trim($query);
+      
+      if(!$this->execute($query, $sql->bindings($query))) return false;
     }
 
     return true;
@@ -371,8 +374,9 @@ class Database {
    * @return boolean
    */
   public function dropTable($table) {
-    $sql = new SQL($this);
-    return $this->execute($sql->dropTable($table));
+    $sql   = new SQL($this);
+    $query = $sql->dropTable($table);
+    return $this->execute($query, $sql->bindings($query));
   }
 
   /**

--- a/lib/database/query.php
+++ b/lib/database/query.php
@@ -197,11 +197,7 @@ class Query {
    * @return object
    */
   public function select($select) {
-    if(is_string($select)) {
-      $this->select = $select;
-    } else {
-      $this->select = implode(', ', $select);
-    }
+    $this->select = $select;
     return $this;
   }
 
@@ -332,7 +328,7 @@ class Query {
         // ->where(array('username' => 'myuser'));
         } else if(is_array($args[0])) {
 
-          $sql = new SQL($this->database);
+          $sql = new SQL($this->database, $this);
 
           // simple array mode (AND operator)
           $where = $sql->values($args[0], ' AND ');
@@ -520,7 +516,7 @@ class Query {
    */
   public function build($type) {
 
-    $sql = new SQL($this->database);
+    $sql = new SQL($this->database, $this);
 
     switch($type) {
       case 'select':

--- a/lib/database/query.php
+++ b/lib/database/query.php
@@ -379,6 +379,7 @@ class Query {
           if(!$this->database->validateColumn($table, $column)) {
             throw new Error('Invalid column ' . $args[0]);
           }
+          $key = $sql->combineIdentifier($table, $column);
 
           // ->where('username', 'in', array('myuser', 'myotheruser'));
           if(is_array($args[2])) {
@@ -398,7 +399,7 @@ class Query {
             }
 
             // add that to the where clause in parenthesis
-            $where = $table . '.' . $column . ' ' . $predicate . ' (' . implode(', ', $values) . ')';
+            $where = $key . ' ' . $predicate . ' (' . implode(', ', $values) . ')';
 
             $this->bindings($bindings);
 
@@ -418,7 +419,7 @@ class Query {
             $valueBinding = sql::generateBindingName('value');
             $bindings[$valueBinding] = $args[2];
             
-            $where = $table . '.' . $column . ' ' . $predicate . ' ' . $valueBinding;
+            $where = $key . ' ' . $predicate . ' ' . $valueBinding;
             
             $this->bindings($bindings);
 
@@ -670,7 +671,7 @@ class Query {
         throw new Error('Invalid column ' . $column);
       }
       
-      $column = $table . '.' . $columnPart;
+      $column = $sql->combineIdentifier($table, $columnPart);
     }
 
     $fetch  = $this->fetch;
@@ -814,7 +815,10 @@ class Query {
    */
   public function column($column) {
 
-    $results = $this->query($this->select($column)->order($this->primaryKeyName . ' ASC')->build('select'), array(
+    $sql = new SQL($this->database, $this);
+    $primaryKey = $sql->combineIdentifier($this->table, $this->primaryKeyName);
+    
+    $results = $this->query($this->select(array($column))->order($primaryKey . ' ASC')->build('select'), array(
       'iterator' => 'array',
       'fetch'    => 'array',
     ));

--- a/lib/database/query.php
+++ b/lib/database/query.php
@@ -814,7 +814,7 @@ class Query {
           $sql = new SQL($this->database, $this);
 
           // simple array mode (AND operator)
-          $result = $sql->values($this->table, $args[0], ' AND ');
+          $result = $sql->values($this->table, $args[0], ' AND ', true, true);
 
         } else if(is_callable($args[0])) {
 

--- a/lib/database/query.php
+++ b/lib/database/query.php
@@ -78,9 +78,6 @@ class Query {
   // Boolean to enable query debugging
   protected $debug = false;
 
-  // an array with reserved sql values
-  protected static $literals = array('NOW()');
-
   /**
    * Constructor
    *

--- a/lib/database/query.php
+++ b/lib/database/query.php
@@ -12,7 +12,7 @@ use Sql;
  *
  * Database Query
  *
- * The query builder is used by the DB class
+ * The query builder is used by the Database class
  * to build SQL queries in a fluent, jquery-style way
  *
  * @package   Kirby Toolkit
@@ -25,7 +25,7 @@ class Query {
 
   const ERROR_INVALID_QUERY_METHOD = 0;
 
-  protected $db = null;
+  protected $database = null;
 
   // The object which should be fetched for each row
   protected $fetch = 'Obj';
@@ -84,11 +84,12 @@ class Query {
   /**
    * Constructor
    *
+   * @param Database $database Database object
    * @param string $table Optional name of the table, which should be queried
    */
-  public function __construct($db, $table) {
-    $this->db    = $db;
-    $this->table = $table;
+  public function __construct($database, $table) {
+    $this->database = $database;
+    $this->table    = $table;
   }
 
   /**
@@ -334,7 +335,7 @@ class Query {
         // ->where(array('username' => 'myuser'));
         } else if(is_array($args[0])) {
 
-          $sql = new SQL($this->db);
+          $sql = new SQL($this->database);
 
           // simple array mode (AND operator)
           $where = $sql->values($args[0], ' AND ');
@@ -381,14 +382,14 @@ class Query {
 
             // build a list of escaped values
             $values = array();
-            foreach($args[2] as $value) $values[] = '"' . $this->db->escape($value) . '"';
+            foreach($args[2] as $value) $values[] = '"' . $this->database->escape($value) . '"';
 
             // add that to the where clause in parenthesis
             $where = $args[0] . ' ' . trim($args[1]) . ' (' . implode(', ', $values) . ')';
 
           // ->where('username', 'like', 'myuser');
           } else {
-            $where = $args[0] . ' ' . trim($args[1]) . ' "' . $this->db->escape($args[2]) . '"';
+            $where = $args[0] . ' ' . trim($args[1]) . ' "' . $this->database->escape($args[2]) . '"';
           }
 
         }
@@ -522,7 +523,7 @@ class Query {
    */
   public function build($type) {
 
-    $sql = new SQL($this->db);
+    $sql = new SQL($this->database);
 
     switch($type) {
       case 'select':
@@ -651,9 +652,9 @@ class Query {
       'options'  => $params
     );
 
-    if($this->fail) $this->db->fail();
+    if($this->fail) $this->database->fail();
 
-    $result = $this->db->query($query, $this->bindings(), $params);
+    $result = $this->database->query($query, $this->bindings(), $params);
     $this->reset();
     return $result;
 
@@ -674,9 +675,9 @@ class Query {
       'options'  => $params
     );
 
-    if($this->fail) $this->db->fail();
+    if($this->fail) $this->database->fail();
 
-    $result = $this->db->execute($query, $this->bindings(), $params);
+    $result = $this->database->execute($query, $this->bindings(), $params);
     $this->reset();
     return $result;
 
@@ -813,7 +814,7 @@ class Query {
    */
   public function insert($values = null) {
     $query = $this->execute($this->values($values)->build('insert'));
-    return ($query) ? $this->db->lastId() : false;
+    return ($query) ? $this->database->lastId() : false;
   }
 
   /**

--- a/lib/sql.php
+++ b/lib/sql.php
@@ -413,7 +413,7 @@ sql::registerMethod('createTable', function($sql, $table, $columns = array()) {
         $template = '{column.name} INT(11) UNSIGNED {column.null} {column.default}';
         break;
       case 'timestamp':
-        $template = '{column.name} INT(11) UNSIGNED {column.null} {column.default}';
+        $template = '{column.name} TIMESTAMP {column.null} {column.default}';
         break;
       default:
         throw new Error('Unsupported column type: ' . $column['type']);

--- a/lib/sql.php
+++ b/lib/sql.php
@@ -6,7 +6,7 @@
  * SQL Query builder
  *
  * @package   Kirby Toolkit
- * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @author    Bastian Allgeier <bastian@getkirby.com>, Lukas Bestle <lukas@getkirby.com>
  * @link      http://getkirby.com
  * @copyright Bastian Allgeier
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
@@ -14,313 +14,555 @@
 class Sql {
 
   // list of literals which should not be escaped in queries
-  protected $literals = array('NOW()', null);
-
-  // the parent db connection
-  protected $db;
+  public static $literals = array('NOW()', null);
+  
+  // sql formatting methods, defined below
+  public static $methods = array();
+  
+  // the parent database connection and database query
+  protected $database;
+  protected $dbquery;
+  
+  // list of bindings by sql query string that defines them
+  protected $bindings = array();
 
   /**
    * Constructor
    *
-   * @param object $db
+   * @param Database $database
+   * @param Database\Query $dbquery Database query that is used to set the bindings directly
    */
-  public function __construct($db) {
-    $this->db = $db;
+  public function __construct($database, $dbquery = null) {
+    $this->database = $database;
+    $this->dbquery  = $dbquery;
   }
 
   /**
-   * Builds a select clause
+   * Sets and returns query-specific bindings
    *
-   * @param array $params List of parameters for the select clause. Check out the defaults for more info.
-   * @return string
+   * @param string $query SQL query string that contains the bindings
+   * @param array $values Array of bindings to set (null to get the bindings)
+   * @return array
    */
-  public function select($params = array()) {
-
-    $defaults = array(
-      'table'    => '',
-      'columns'  => '*',
-      'join'     => false,
-      'distinct' => false,
-      'where'    => false,
-      'group'    => false,
-      'having'   => false,
-      'order'    => false,
-      'offset'   => 0,
-      'limit'    => false,
-    );
-
-    $options = array_merge($defaults, $params);
-    $query   = array();
-
-    $query[] = 'SELECT';
-
-    // select distinct values
-    if($options['distinct']) $query[] = 'DISTINCT';
-
-    $query[] = empty($options['columns']) ? '*' : implode(', ', (array)$options['columns']);
-    $query[] = 'FROM ' . $options['table'];
-
-    if(!empty($options['join'])) {
-      foreach($options['join'] as $join) {
-        $query[] = ltrim(strtoupper(a::get($join, 'type', '')) . ' JOIN ') . $join['table'] . ' ON ' . $join['on'];
-      }
-    }
-
-    if(!empty($options['where'])) {
-      $query[] = 'WHERE ' . $options['where'];
-    }
-
-    if(!empty($options['group'])) {
-      $query[] = 'GROUP BY ' . $options['group'];
-    }
-
-    if(!empty($options['having'])) {
-      $query[] = 'HAVING ' . $options['having'];
-    }
-
-    if(!empty($options['order'])) {
-      $query[] = 'ORDER BY ' . $options['order'];
-    }
-
-    if($options['offset'] > 0 || $options['limit']) {
-      if(!$options['limit']) $options['limit'] = '18446744073709551615';
-      $query[] = 'LIMIT ' . $options['offset'] . ', ' . $options['limit'];
-    }
-
-    return implode(' ', $query);
-
-  }
-
-  /**
-   * Builds an insert clause
-   *
-   * @param array $params List of parameters for the insert clause. See defaults for more info
-   * @return string
-   */
-  public function insert($params = array()) {
-
-    $defaults = array(
-      'table'  => '',
-      'values' => false,
-    );
-
-    $options = array_merge($defaults, $params);
-    $query   = array();
-
-    $query[] = 'INSERT INTO ' . $options['table'];
-    $query[] = $this->values($options['values'], ', ', false);
-
-    return implode(' ', $query);
-
-  }
-
-  /**
-   * Builds an update clause
-   *
-   * @param array $params List of parameters for the update clause. See defaults for more info
-   * @return string
-   */
-  public function update($params = array()) {
-
-    $defaults = array(
-      'table'  => '',
-      'values' => false,
-      'where'  => false,
-    );
-
-    $options = array_merge($defaults, $params);
-    $query   = array();
-
-    $query[] = 'UPDATE ' . $options['table'] . ' SET';
-    $query[] = $this->values($options['values']);
-
-    if(!empty($options['where'])) {
-      $query[] = 'WHERE ' . $options['where'];
-    }
-
-    return implode(' ', $query);
-
-  }
-
-  /**
-   * Builds a delete clause
-   *
-   * @param array $params List of parameters for the delete clause. See defaults for more info
-   * @return string
-   */
-  public function delete($params = array()) {
-
-    $defaults = array(
-      'table'  => '',
-      'where'  => false,
-    );
-
-    $options = array_merge($defaults, $params);
-    $query   = array();
-
-    $query[] = 'DELETE FROM ' . $options['table'];
-
-    if(!empty($options['where'])) {
-      $query[] = 'WHERE ' . $options['where'];
-    }
-
-    return implode(' ', $query);
-
-  }
-
-  /**
-   * Builds a safe list of values for insert, select or update queries
-   *
-   * @param mixed $values A value string or array of values
-   * @param string $separator A separator which should be used to join values
-   * @param boolean $set If true builds a set list of values for update clauses
-   * @return string
-   */
-  public function values($values, $separator = ', ', $set = true) {
-
-    if(!is_array($values)) return $values;
-
-    if($set) {
-
-      $output = array();
-
-      foreach($values AS $key => $value) {
-        if(in_array($value, $this->literals, true)) {
-          $output[] = $key . ' = ' . (($value === null)? 'null' : $value);
-        } elseif(is_array($value)) {
-          $output[] = $key . " = '" . json_encode($value) . "'";
-        } else {
-          $output[] = $key . " = '" . $this->db->escape($value) . "'";
-        }
-      }
-
-      return implode($separator, $output);
-
+  public function bindings($query, $values = null) {
+    if(is_null($values)) {
+      return a::get($this->bindings, $query, array());
     } else {
-
-      $fields = array();
-      $output = array();
-
-      foreach($values AS $key => $value) {
-        $fields[] = $key;
-        if(in_array($value, $this->literals, true)) {
-          $output[] = ($value === null)? 'null' : $value;
-        } elseif(is_array($value)) {
-          $output[] = "'" . $this->db->escape(json_encode($value)) . "'";
-        } else {
-          $output[] = "'" . $this->db->escape($value) . "'";
-        }
-      }
-
-      return '(' . implode($separator, $fields) . ') VALUES (' . implode($separator, $output) . ')';
-
+      if(!is_null($query)) $this->bindings[$query] = $values;
+      
+      // directly register bindings if possible
+      if($this->dbquery) $this->dbquery->bindings($values);
     }
-
   }
-
+  
   /**
-   * Creates the sql for dropping a single table
+   * Calls an SQL method using the correct database type
    *
-   * @param string $table
+   * @param string $method
+   * @param array $arguments
+   * @return mixed
+   */
+  public function __call($method, $arguments) {
+    $type = $this->database->type();
+    
+    if(isset(static::$methods[$type][$method])) {
+      $method = static::$methods[$type][$method];
+    } else {
+      // fallback to shared method
+      if(!isset(static::$methods['_shared'][$method])) {
+        throw new Error('SQL method ' . $method . ' is not defined for database type ' . $type);
+      }
+      
+      $method = static::$methods['_shared'][$method];
+    }
+    
+    // pass the sql object as first argument
+    array_unshift($arguments, $this);
+    return call($method, $arguments);
+  }
+  
+  /**
+   * Registers a method for a specified database type
+   * The function must take this SQL object as first parameter and set bindings on it
+   *
+   * @param string $name
+   * @param callable $function
+   * @param string $type 'mysql', 'sqlite' or '_shared'
+   */
+  public static function registerMethod($name, $function, $type = '_shared') {
+    if(!isset(static::$methods[$type])) static::$methods[$type] = array();
+    static::$methods[$type][$name] = $function;
+  }
+  
+  /**
+   * Returns a randomly generated binding name
+   *
+   * @param string $label String that contains lowercase letters and numbers to use as a readable identifier
    * @return string
    */
-  public function dropTable($table) {
-    return 'DROP TABLE `' . $table . '`';
-  }
-
-  /**
-   * Creates a table with a simple scheme array for columns
-   *
-   * @todo  add more options per column
-   * @param string $table The table name
-   * @param array $columns
-   * @return string
-   */
-  public function createTable($table, $columns = array()) {
-
-    $type   = strtolower($this->db->type());
-    $output = array();
-    $keys   = array();
-
-    if(!in_array($type, array('mysql', 'sqlite'))) throw new Exception('Unsupported database type: ' . $type);
-
-    foreach($columns as $name => $column) {
-
-      $template = array();
-
-      switch($column['type']) {
-        case 'id':
-          $template['mysql']  = '"{column.name}" INT(11) UNSIGNED NOT NULL AUTO_INCREMENT';
-          $template['sqlite'] = '"{column.name}" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE';
-          $keys[$name] = 'PRIMARY';
-          break;
-        case 'varchar':
-          $template['mysql']  = '"{column.name}" varchar(255) {column.null} {column.default}';
-          $template['sqlite'] = '"{column.name}" TEXT {column.null} {column.key} {column.default}';
-          break;
-        case 'text':
-          $template['mysql']  = '"{column.name}" TEXT';
-          $template['sqlite'] = '"{column.name}" TEXT {column.null} {column.key} {column.default}';
-          break;
-        case 'int':
-          $template['mysql']  = '"{column.name}" INT(11) UNSIGNED {column.null} {column.default}';
-          $template['sqlite'] = '"{column.name}" INTEGER {column.null} {column.key} {column.default}';
-          break;
-        case 'timestamp':
-          $template['mysql']  = '"{column.name}" INT(11) UNSIGNED {column.null} {column.default}';
-          $template['sqlite'] = '"{column.name}" INTEGER {column.null} {column.key} {column.default}';
-          break;
-        default:
-          throw new Exception('Unsupported column type: ' . $column['type']);
-      }
-
-      $key = false;
-      if(isset($column['key'])) {
-        $key = strtoupper($column['key']);
-        $keys[$name] = $key;
-      }
-
-      $defaultValue = null;
-      if(isset($column['default'])) {
-        $defaultValue = is_integer($column['default']) ? $column['default'] : "'" . $column['default'] . "'";
-      }
-
-      $output[] = trim(str::template($template[$type], array(
-        'column.name'    => $name,
-        'column.null'    => r(a::get($column, 'null') === false, 'NOT NULL', 'NULL'),
-        'column.key'     => r($key && $key != 'INDEX', $key, false),
-        'column.default' => r(!is_null($defaultValue), 'DEFAULT ' . $defaultValue),
-      )));
-
-    }
-
-    // all columns
-    $inner = implode(', ' . PHP_EOL, $output);
-
-    // add keys for mysql
-    if($type ==  'mysql') {
-      foreach($keys as $name => $key) {
-        $inner .= ', ' . PHP_EOL . trim(r($key != 'INDEX', $key) . ' KEY (`' . $name . '`)');
-      }
-    }
-
-    // make it a string
-    $output = 'CREATE TABLE "' . $table . '" (' . PHP_EOL . $inner . PHP_EOL . ');';
-
-    if($type == 'mysql') {
-      $output = str_replace('"', '`', $output);
-    }
-
-    // add index keys for sqlite
-    if($type == 'sqlite') {
-      foreach($keys as $name => $key) {
-        if($key != 'INDEX') continue;
-        $output .= PHP_EOL . 'CREATE INDEX "' . $name . '" ON "' . $table . '" ("' . $name . '");';
-      }
-    }
-
-    return $output;
-
+  public static function generateBindingName($label) {
+    // make sure that the binding name is valid to prevent injections
+    if(!preg_match('/^[a-z0-9]+$/', $label)) $label = 'invalid';
+    
+    return ':' . $label . '_' . uniqid();
   }
 
 }
+
+/**
+ * Builds a select clause
+ *
+ * @param array $params List of parameters for the select clause. Check out the defaults for more info.
+ * @return string
+ */
+sql::registerMethod('select', function($sql, $params = array()) {
+  
+  $defaults = array(
+    'table'    => '',
+    'columns'  => '*',
+    'join'     => false,
+    'distinct' => false,
+    'where'    => false,
+    'group'    => false,
+    'having'   => false,
+    'order'    => false,
+    'offset'   => 0,
+    'limit'    => false,
+  );
+
+  $options  = array_merge($defaults, $params);
+  $query    = array();
+  $bindings = array();
+
+  $query[] = 'SELECT';
+
+  // select distinct values
+  if($options['distinct']) $query[] = 'DISTINCT';
+  
+  // columns
+  if(empty($options['columns'])) {
+    $query[] = '*';
+  } else if(is_array($options['columns'])) {
+    $query[] = implode(', ', $options['columns']);
+  } else {
+    $query[] = $options['columns'];
+  }
+  
+  // table
+  $query[] = 'FROM ' . $options['table'];
+  
+  // join
+  if(!empty($options['join'])) {
+    foreach($options['join'] as $join) {
+      $joinType = ltrim(strtoupper(a::get($join, 'type', '')) . ' JOIN');
+      if(!in_array($joinType, array(
+        'JOIN', 'INNER JOIN',
+        'OUTER JOIN',
+        'LEFT OUTER JOIN', 'LEFT JOIN',
+        'RIGHT OUTER JOIN', 'RIGHT JOIN',
+        'FULL OUTER JOIN', 'FULL JOIN',
+        'NATURAL JOIN',
+        'CROSS JOIN',
+        'SELF JOIN'
+      ))) throw new Error('Invalid join type ' . $joinType);
+      
+      // ON can't be escaped here
+      $query[] = $joinType . ' ' . $join['table'] . ' ON ' . $join['on'];
+    }
+  }
+  
+  // where
+  if(!empty($options['where'])) {
+    // WHERE can't be escaped here
+    $query[] = 'WHERE ' . $options['where'];
+  }
+  
+  // group
+  if(!empty($options['group'])) {
+    // GROUP BY can't be escaped here
+    $query[] = 'GROUP BY ' . $options['group'];
+  }
+  
+  // having
+  if(!empty($options['having'])) {
+    // HAVING can't be escaped here
+    $query[] = 'HAVING ' . $options['having'];
+  }
+
+  // order
+  if(!empty($options['order'])) {
+    // ORDER BY can't be escaped here
+    $query[] = 'ORDER BY ' . $options['order'];
+  }
+  
+  // offset and limit
+  if($options['offset'] > 0 || $options['limit']) {
+    if(!$options['limit']) $options['limit'] = '18446744073709551615';
+    
+    $offsetBinding = sql::generateBindingName('offset');
+    $bindings[$offsetBinding] = $options['offset'];
+    $limitBinding = sql::generateBindingName('limit');
+    $bindings[$limitBinding] = $options['limit'];
+    
+    $query[] = 'LIMIT ' . $offsetBinding . ', ' . $limitBinding;
+  }
+
+  $query = implode(' ', $query);
+  
+  $sql->bindings($query, $bindings);
+  return $query;
+
+});
+
+/**
+ * Builds an insert clause
+ *
+ * @param array $params List of parameters for the insert clause. See defaults for more info.
+ * @return string
+ */
+sql::registerMethod('insert', function($sql, $params = array()) {
+
+  $defaults = array(
+    'table'  => '',
+    'values' => false,
+  );
+
+  $options  = array_merge($defaults, $params);
+  $query    = array();
+  $bindings = array();
+
+  $query[] = 'INSERT INTO ' . $options['table'];
+  $query[] = $sql->values($options['values'], ', ', false);
+
+  $query = implode(' ', $query);
+  
+  $sql->bindings($query, $bindings);
+  return $query;
+
+});
+
+/**
+ * Builds an update clause
+ *
+ * @param array $params List of parameters for the update clause. See defaults for more info.
+ * @return string
+ */
+sql::registerMethod('update', function($sql, $params = array()) {
+
+  $defaults = array(
+    'table'  => '',
+    'values' => false,
+    'where'  => false,
+  );
+
+  $options  = array_merge($defaults, $params);
+  $query    = array();
+  $bindings = array();
+
+  $query[] = 'UPDATE ' . $options['table'] . ' SET';
+  $query[] = $sql->values($options['values']);
+
+  if(!empty($options['where'])) {
+    // WHERE can't be escaped here
+    $query[] = 'WHERE ' . $options['where'];
+  }
+
+  $query = implode(' ', $query);
+  
+  $sql->bindings($query, $bindings);
+  return $query;
+
+});
+
+/**
+ * Builds a delete clause
+ *
+ * @param array $params List of parameters for the delete clause. See defaults for more info.
+ * @return string
+ */
+sql::registerMethod('delete', function($sql, $params = array()) {
+
+  $defaults = array(
+    'table'  => '',
+    'where'  => false,
+  );
+
+  $options  = array_merge($defaults, $params);
+  $query    = array();
+  $bindings = array();
+
+  $query[] = 'DELETE FROM ' . $options['table'];
+
+  if(!empty($options['where'])) {
+    // WHERE can't be escaped here
+    $query[] = 'WHERE ' . $options['where'];
+  }
+
+  $query = implode(' ', $query);
+  
+  $sql->bindings($query, $bindings);
+  return $query;
+
+});
+
+/**
+ * Builds a safe list of values for insert, select or update queries
+ *
+ * @param mixed $values A value string or array of values
+ * @param string $separator A separator which should be used to join values
+ * @param boolean $set If true builds a set list of values for update clauses
+ * @return string
+ */
+sql::registerMethod('values', function($sql, $values, $separator = ', ', $set = true) {
+
+  if(!is_array($values)) return $values;
+  
+  if($set) {
+
+    $output   = array();
+    $bindings = array();
+
+    foreach($values as $key => $value) {
+      if(in_array($value, sql::$literals, true)) {
+        $output[] = $key . ' = ' . (($value === null)? 'null' : $value);
+        continue;
+      } elseif(is_array($value)) {
+        $value = json_encode($value);
+      }
+      
+      $valueBinding = sql::generateBindingName('value');
+      $bindings[$valueBinding] = $value;
+      
+      $output[] = $key . ' = ' . $valueBinding;
+    }
+    
+    $sql->bindings(null, $bindings);
+    return implode($separator, $output);
+
+  } else {
+
+    $fields   = array();
+    $output   = array();
+    $bindings = array();
+
+    foreach($values as $key => $value) {
+      $fields[] = $key;
+      
+      if(in_array($value, sql::$literals, true)) {
+        $output[] = ($value === null)? 'null' : $value;
+        continue;
+      } elseif(is_array($value)) {
+        $value = json_encode($value);
+      }
+      
+      $valueBinding = sql::generateBindingName('value');
+      $bindings[$valueBinding] = $value;
+      
+      $output[] = $valueBinding;
+    }
+
+    $sql->bindings(null, $bindings);
+    return '(' . implode($separator, $fields) . ') VALUES (' . implode($separator, $output) . ')';
+
+  }
+
+});
+
+/**
+ * Creates the sql for dropping a single table
+ *
+ * @param string $table
+ * @return string
+ */
+sql::registerMethod('dropTable', function($sql, $table) {
+
+  return 'DROP TABLE ' . $table;
+
+});
+
+/**
+ * Creates a table with a simple scheme array for columns
+ * MySQL version
+ *
+ * @todo  add more options per column
+ * @param string $table The table name
+ * @param array $columns
+ * @return string
+ */
+sql::registerMethod('createTable', function($sql, $table, $columns = array()) {
+
+  $output   = array();
+  $keys     = array();
+  $bindings = array();
+
+  foreach($columns as $name => $column) {
+    // column type
+    if(!isset($column['type'])) throw new Error('No column type given for column ' . $name);
+    switch($column['type']) {
+      case 'id':
+        $template = '{column.name} INT(11) UNSIGNED NOT NULL AUTO_INCREMENT';
+        $column['key'] = 'PRIMARY';
+        break;
+      case 'varchar':
+        $template = '{column.name} varchar(255) {column.null} {column.default}';
+        break;
+      case 'text':
+        $template = '{column.name} TEXT';
+        break;
+      case 'int':
+        $template = '{column.name} INT(11) UNSIGNED {column.null} {column.default}';
+        break;
+      case 'timestamp':
+        $template = '{column.name} INT(11) UNSIGNED {column.null} {column.default}';
+        break;
+      default:
+        throw new Error('Unsupported column type: ' . $column['type']);
+    }
+
+    // null
+    if(a::get($column, 'null') === false) {
+      $null = 'NOT NULL';
+    } else {
+      $null = 'NULL';
+    }
+
+    // indexes/keys
+    $key = false;
+    if(isset($column['key'])) {
+      $column['key'] = strtoupper($column['key']);
+      
+      // backwards compatibility
+      if($column['key'] === 'PRIMARY') $column['key'] = 'PRIMARY KEY';
+      
+      if(in_array($column['key'], array('PRIMARY KEY', 'INDEX'))) {
+        $key = $column['key'];
+        $keys[$name] = $key;
+      }
+    }
+
+    // default value
+    $defaultBinding = null;
+    if(isset($column['default'])) {
+      $defaultBinding = sql::generateBindingName('default');
+      $bindings[$defaultBinding] = $column['default'];
+    }
+
+    $output[] = trim(str::template($template, array(
+      'column.name'    => $name,
+      'column.null'    => $null,
+      'column.default' => r(!is_null($defaultBinding), 'DEFAULT ' . $defaultBinding),
+    )));
+
+  }
+
+  // combine columns
+  $inner = implode(',' . PHP_EOL, $output);
+
+  // add keys
+  foreach($keys as $name => $key) {
+    $inner .= ',' . PHP_EOL . $key . ' (' . $name . ')';
+  }
+
+  // make it a string
+  $query = 'CREATE TABLE ' . $table . ' (' . PHP_EOL . $inner . PHP_EOL . ')';
+
+  $sql->bindings($query, $bindings);
+  return $query;
+
+}, 'mysql');
+
+/**
+ * Creates a table with a simple scheme array for columns
+ * SQLite version
+ *
+ * @todo  add more options per column
+ * @param string $table The table name
+ * @param array $columns
+ * @return string
+ */
+sql::registerMethod('createTable', function($sql, $table, $columns = array()) {
+
+  $output   = array();
+  $keys     = array();
+  $bindings = array();
+
+  foreach($columns as $name => $column) {
+    // column type
+    if(!isset($column['type'])) throw new Error('No column type given for column ' . $name);
+    switch($column['type']) {
+      case 'id':
+        $template = '{column.name} INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE';
+        break;
+      case 'varchar':
+        $template = '{column.name} TEXT {column.null} {column.key} {column.default}';
+        break;
+      case 'text':
+        $template = '{column.name} TEXT {column.null} {column.key} {column.default}';
+        break;
+      case 'int':
+        $template = '{column.name} INTEGER {column.null} {column.key} {column.default}';
+        break;
+      case 'timestamp':
+        $template = '{column.name} INTEGER {column.null} {column.key} {column.default}';
+        break;
+      default:
+        throw new Error('Unsupported column type: ' . $column['type']);
+    }
+
+    // null
+    if(a::get($column, 'null') === false) {
+      $null = 'NOT NULL';
+    } else {
+      $null = 'NULL';
+    }
+
+    // indexes/keys
+    $key = false;
+    if(isset($column['key'])) {
+      $column['key'] = strtoupper($column['key']);
+      
+      // backwards compatibility
+      if($column['key'] === 'PRIMARY') $column['key'] = 'PRIMARY KEY';
+      
+      if(in_array($column['key'], array('PRIMARY KEY', 'INDEX'))) {
+        $key = $column['key'];
+        $keys[$name] = $key;
+      }
+    }
+
+    // default value
+    $defaultBinding = null;
+    if(isset($column['default'])) {
+      $defaultBinding = sql::generateBindingName('default');
+      $bindings[$defaultBinding] = $column['default'];
+    }
+
+    $output[] = trim(str::template($template, array(
+      'column.name'    => $name,
+      'column.null'    => $null,
+      'column.key'     => r($key && $key != 'INDEX', $key),
+      'column.default' => r(!is_null($defaultBinding), 'DEFAULT ' . $defaultBinding),
+    )));
+
+  }
+
+  // combine columns
+  $inner = implode(',' . PHP_EOL, $output);
+
+  // make it a string
+  $query = 'CREATE TABLE "' . $table . '" (' . PHP_EOL . $inner . PHP_EOL . ')';
+
+  // set bindings for our first query
+  $sql->bindings($query, $bindings);
+  
+  // add index keys
+  foreach($keys as $name => $key) {
+    if($key != 'INDEX') continue;
+  
+    $indexQuery = 'CREATE INDEX ' . $name . ' ON "' . $table . '" (' . $name . ')';
+    $query .= ';' . PHP_EOL . $indexQuery;
+  }
+  
+  return $query;
+
+}, 'sqlite');

--- a/test/DbTest.php
+++ b/test/DbTest.php
@@ -122,7 +122,7 @@ class DbTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testLastError() {
-    $result = db::select('nonexisting', '*');
+    $result = db::select('users', 'nonexisting');
     $this->assertInstanceOf('PDOException', db::lastError());
   }
 


### PR DESCRIPTION
To improve security and code readability, I have refactored the database classes `Database`, `Database\Query` and `Sql`. Some minor features have been added along the way. Full changelog:

- Quote identifiers (tables and columns) to allow using reserved names and strange characters in identifiers
- Validate table and column names using a whitelist
- Use bindings instead of quoting internally
- Bind all parameters that can be bound (everything except SQL string parameters)
- Validate SQL keywords, predicates and operators like `<=`, `IN` and `PRIMARY KEY`
- Split up SQL class into MySQL and SQLite specific methods where necessary to improve code readability
- `$query->having()`: Support for the `where()` syntax
- Use TIMESTAMP type for timestamps in MySQL instead of INT
- Disable prepare emulation to use native prepared statements where possible
- Improvements and fixes for SQLite databases
- Comment and naming improvements

Because of the added validations, some existing code may break (that's good!). Also, maybe there are some edge cases that will currently not work. So this definitely needs to be included in a Kirby beta before release.