### PR TITLE
Replace x with × in dimensions

### DIFF
--- a/lib/dimensions.php
+++ b/lib/dimensions.php
@@ -294,12 +294,12 @@ class Dimensions {
   }
 
   /**
-   * Echos the dimensions as width x height
+   * Echos the dimensions as width × height
    *
    * @return string
    */
   public function __toString() {
-    return $this->width . ' x ' . $this->height;
+    return $this->width . ' × ' . $this->height;
   }
 
 }


### PR DESCRIPTION
Replaces the ‘x’ with the typographically correct times symbol × (aka `&times;`).