### PR TITLE
Allow the `attr()` function to handle multiple values

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -190,7 +190,7 @@ class Html {
     } else if(is_bool($value)) {
       return $value === true ? strtolower($name) : '';
     } else {
-      return strtolower($name) . '="' . $value . '"';      
+      return strtolower($name) . '="' . ( is_array($value) ? implode(' ', $value) : $value ) . '"';      
     }
 
   }


### PR DESCRIPTION
In my kirby patterns I like to keep my html classes organized within arrays, which makes it easier to filter undesired classes. It would be useful to allow users to pass such kind of arrays to the `attr()` helper function as it reduces the amount of required code:

Following an example:

Before:
```php
<nav <?php echo attr('class', implode(' ', ['navbar', 'navbar--justify'])); ?>>
   <!-- … -->
</nav>
```

After:
```php
<nav <?php echo attr('class', ['navbar', 'navbar--justify']); ?>>
   <!-- … -->
</nav>
```