### PR TITLE
Fix kirby installation through Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,6 @@
     "forum": "http://forum.getkirby.com",
     "source": "https://github.com/getkirby/toolkit"
   },
-  "autoload": {
-    "files": ["bootstrap.php"]
-  },
   "require": {
     "php": ">=5.4.0"
   }


### PR DESCRIPTION
If kirby was installed through Composer :
https://forum.getkirby.com/t/how-to-use-composer-to-install-kirby-toolkit-panel/2850
kirby/bootstrap.php include kirby/tookit/bootstrap.php which
declare the load function.
Then, when i include the composer autoloader, i've the following error :
Cannot redeclare load()

Because the toolkir composer.json file tell to Composer to autoload
the toolkit/bootstrap.php, which is loaded again and throw the error.