### PR TITLE
Return $key instead of empty $default

### DIFF
--- a/lib/silo.php
+++ b/lib/silo.php
@@ -27,6 +27,7 @@ class Silo {
 
   public static function get($key = null, $default = null) {
     if(empty($key)) return static::$data;
+    $default = isset($default) ? $default : $key;
     return isset(static::$data[$key]) ? static::$data[$key] : $default;
   }
 


### PR DESCRIPTION
Working with `l::get()` in Kirby I think it makes more sense to return the `$key` variable instead of a possibly empty `$default`. This way at least something shows up on the page where missing translated variables should be displayed.