### PR TITLE
`host` option for router

### DIFF
--- a/lib/router.php
+++ b/lib/router.php
@@ -140,7 +140,7 @@ class Router {
     }
 
     foreach($route->method as $method) {
-      $this->routes[strtoupper($method)][$route->pattern] = $route;
+      $this->routes[strtoupper($method)][$route->host . $route->pattern] = $route;
     }
 
     return $route;

--- a/lib/router.php
+++ b/lib/router.php
@@ -108,6 +108,7 @@ class Router {
 
     $defaults = array(
       'pattern'   => $pattern,
+      'host'      => false,
       'https'     => false,
       'ajax'      => false,
       'filter'    => null,
@@ -192,23 +193,26 @@ class Router {
    * Iterate through every route to find a matching route.
    *
    * @param  string $path Optional path to match against
+   * @param  string $host Optional host to match against
    * @return Route
    */
-  public function run($path = null) {
+  public function run($path = null, $host = null) {
 
     $method = r::method();
     $ajax   = r::ajax();
     $https  = r::ssl();
     $routes = a::get($this->routes, $method, array());
 
-    // detect path if not set manually
+    // detect path and host if not set manually
     if($path === null) $path = implode('/', (array)url::fragments(detect::path()));
+    if($host === null) $host = url::host();
 
     // empty urls should never happen
     if(empty($path)) $path = '/';
 
     foreach($routes as $route) {
 
+      if($route->host  && $route->host !== $host) continue;
       if($route->https && !$https) continue;
       if($route->ajax  && !$ajax)  continue;
 


### PR DESCRIPTION
The `host` option can be used together with the pattern to limit a route to a specified host. Required for cross-domain multilang in the CMS.