### PR TITLE
Fixed wrong comparison

### DIFF
--- a/lib/escape.php
+++ b/lib/escape.php
@@ -64,17 +64,11 @@ class Escape {
    * <body>...ESCAPE UNTRUSTED DATA BEFORE PUTTING HERE...</body>
    * <div>...ESCAPE UNTRUSTED DATA BEFORE PUTTING HERE...</div>
    * 
-   * @uses ENT_SUBSTITUE if available (PHP >= 5.4)
-   * 
    * @param  string $string
    * @return string
    */
   public static function html($string) {
-    $flags = ENT_QUOTES;
-    if(defined('ENT_SUBSTITUTE')) {
-      $flags |= ENT_SUBSTITUTE;
-    }
-    return htmlspecialchars($string, $flags, 'UTF-8');
+    return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
   }
   
   /**
@@ -91,17 +85,11 @@ class Escape {
    * < is replaced with &lt;
    * > is replaced with &gt;
    * 
-   * @uses ENT_XML1 if available (PHP >= 5.4)
-   * 
    * @param  string $string
    * @return string 
    */
   public static function xml($string) {
-    if (defined('ENT_XML1')) {
-      return htmlspecialchars($string, ENT_QUOTES | ENT_XML1, 'UTF-8');
-    } else {
-      return str_replace('&#039;', '&apos;', htmlspecialchars($string, ENT_QUOTES, 'UTF-8'));
-    }
+    return htmlspecialchars($string, ENT_QUOTES | ENT_XML1, 'UTF-8');
   }
   
   /**

--- a/lib/escape.php
+++ b/lib/escape.php
@@ -124,9 +124,9 @@ class Escape {
    *                        which is necessary in case of unquoted HTML attributes.
    * @return string
    */
-  public static function attr($string, $strict = false) {
+  public static function attr($string, $strict = true) {
     if(static::noNeedToEscape($string)) return $string;
-    if($strict !== true) {
+    if($strict === true) {
       return preg_replace_callback('/[^a-z0-9,\.\-_]/iSu', 'static::escapeAttrChar', $string);
     }
     return static::html($string);


### PR DESCRIPTION
$strict should always be the default to cover cases where attributes might be unquoted or quoted illegally (e.g. backticks are valid quotes for IE)