### PR TITLE
Added exclude list of files for composer archives.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
   },
   "require": {
     "php": ">=5.4.0"
+  },
+  "archive": {
+    "exclude": ["/.travis.yml", "/.gitignore", "/phpunit.xml", "/tests"]
   }
 }


### PR DESCRIPTION
The idea should be that packages are as small as possible and contain only the necessary files to run it.

In regards to tests you could argue that it might be helpful to still include them into a release. I'm open to discussions about that.