### PR TITLE
Fixed wrong comparison

### DIFF
--- a/lib/escape.php
+++ b/lib/escape.php
@@ -124,9 +124,9 @@ class Escape {
    *                        which is necessary in case of unquoted HTML attributes.
    * @return string
    */
-  public static function attr($string, $strict = false) {
+  public static function attr($string, $strict = true) {
     if(static::noNeedToEscape($string)) return $string;
-    if($strict !== true) {
+    if($strict === true) {
       return preg_replace_callback('/[^a-z0-9,\.\-_]/iSu', 'static::escapeAttrChar', $string);
     }
     return static::html($string);


### PR DESCRIPTION
Follow up for closed PR #180 
$strict should always be the default to cover cases where attributes might be unquoted or quoted illegally (e.g. backticks are valid quotes for IE)