### PR TITLE
Improved invalid helper function

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -150,7 +150,7 @@ function h($text, $keepTags = true) {
 
 /**
  * Shortcut for xml::encode()
- * 
+ *
  * @param $text
  * @return string
  */
@@ -160,7 +160,7 @@ function xml($text) {
 
 /**
  * Escape context specific output
- * 
+ *
  * @param  string  $string  Untrusted data
  * @param  string  $context Location of output
  * @param  boolean $strict  Whether to escape an extended set of characters (HTML attributes only)
@@ -272,7 +272,7 @@ function call($function, $arguments = array()) {
 
 /**
  * Parses yaml structured text
- * 
+ *
  * @param $string
  * @return array
  */
@@ -304,7 +304,7 @@ function email($params = array()) {
 
 /**
  * Shortcut for the upload class
- * 
+ *
  * @param $to
  * @param array $params
  * @return Upload
@@ -319,26 +319,33 @@ function upload($to, $params = array()) {
  * @param array $data
  * @param array $rules
  * @param array $messages
- * @return mixed
+ * @return array
  */
-function invalid($data, $rules, $messages = array()) {
-  $errors = array();
-  foreach($rules as $field => $validations) {
-    foreach($validations as $method => $options) {
-      if(is_numeric($method)) $method = $options;
-      if($method == 'required') {
-        if(!isset($data[$field]) || (empty($data[$field]) && $data[$field] !== 0)) {
+function invalid($data, $rules, $messages = []) {
+  $errors = [];
+
+  foreach ($rules as $field => $validations) {
+    foreach ($validations as $method => $options) {
+
+      if (is_numeric($method)) $method = $options;
+      // See: http://php.net/manual/en/types.comparisons.php
+      // only false for: null, undefined variable, '', []
+      $filled = isset($data[$field]) && $data[$field] !== '' && $data[$field] !== [];
+
+      if ($method === 'required') {
+        if (!$filled) {
           $errors[$field] = a::get($messages, $field, $field);
         }
-      } else if(!empty($data[$field]) || $data[$field] === 0) {
-        if(!is_array($options)) $options = array($options);
+      } else if ($filled) {
+        if (!is_array($options)) $options = [$options];
         array_unshift($options, a::get($data, $field));
-        if(!call(array('v', $method), $options)) {
+        if (!call(['v', $method], $options)) {
           $errors[$field] = a::get($messages, $field, $field);
         }
       }
     }
   }
+
   return array_unique($errors);
 }
 

--- a/test/HelpersTest.php
+++ b/test/HelpersTest.php
@@ -10,12 +10,14 @@ class HelpersTest extends PHPUnit_Framework_TestCase {
       'username' => 123,
       'email' => 'homersimpson.com',
       'zip' => 'abc',
+      'website' => '',
     ];
 
     $rules = [
       'username' => ['alpha'],
       'email' => ['required', 'email'],
       'zip' => ['integer'],
+      'website' => ['url'],
     ];
 
     $messages = [
@@ -31,6 +33,7 @@ class HelpersTest extends PHPUnit_Framework_TestCase {
       'username' => 'homer',
       'email' => 'homer@simpson.com',
       'zip' => 123,
+      'website' => 'http://example.com',
     ];
 
     $result  = invalid($data, $rules, $messages);
@@ -100,6 +103,39 @@ class HelpersTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($messages, $result);
 
     $result  = invalid(['username' => 'homer'], $rules, $messages);
+    $this->assertEquals([], $result);
+  }
+
+  public function testMultipleMessages()
+  {
+    $data = ['username' => ''];
+    $rules = ['username' => ['required', 'alpha', 'min' => 4]];
+    $messages = ['username' => [
+      'The username is required',
+      'The username must contain only letters',
+      'The username must be at least 4 characters long',
+    ]];
+
+    $result = invalid(['username' => ''], $rules, $messages);
+    $expected = ['username' => [
+      'The username is required',
+    ]];
+    $this->assertEquals($expected, $result);
+
+    $result = invalid(['username' => 'a1'], $rules, $messages);
+    $expected = ['username' => [
+      'The username must contain only letters',
+      'The username must be at least 4 characters long',
+    ]];
+    $this->assertEquals($expected, $result);
+
+    $result = invalid(['username' => 'ab'], $rules, $messages);
+    $expected = ['username' => [
+      'The username must be at least 4 characters long',
+    ]];
+    $this->assertEquals($expected, $result);
+
+    $result = invalid(['username' => 'abcd'], $rules, $messages);
     $this->assertEquals([], $result);
   }
 }

--- a/test/HelpersTest.php
+++ b/test/HelpersTest.php
@@ -3,31 +3,103 @@
 require_once('lib/bootstrap.php');
 
 class HelpersTest extends PHPUnit_Framework_TestCase {
-  public function testInvalid() {
 
-    $data = array(
+  public function testInvalid()
+  {
+    $data = [
+      'username' => 123,
+      'email' => 'homersimpson.com',
+      'zip' => 'abc',
+    ];
+
+    $rules = [
+      'username' => ['alpha'],
+      'email' => ['required', 'email'],
+      'zip' => ['integer'],
+    ];
+
+    $messages = [
+      'username' => 'The username must not contain numbers',
+      'email' => 'Invalid email',
+      'zip' => 'The ZIP must contain only numbers',
+    ];
+
+    $result  = invalid($data, $rules, $messages);
+    $this->assertEquals($messages, $result);
+
+    $data = [
       'username' => 'homer',
-      'email'    => 'homer@simpson.com',
-      'zip'      => 0,
-      'street'   => ''
-    );
+      'email' => 'homer@simpson.com',
+      'zip' => 123,
+    ];
 
-    $rules = array(
-      'name'     => array('required'), // not set
-      'username' => array('required'), // valid
-      'zip'      => array('required'), // 0 to see if the empty check works correctly
-      'street'   => array('required')  // set but empty
-    );
+    $result  = invalid($data, $rules, $messages);
+    $this->assertEquals([], $result);
+  }
 
-    $messages = array(
-      'name'   => 'The name is required',
-      'street' => 'The street is required'
-    );
+  public function testInvalidSimple()
+  {
+    $data = ['homer', null];
+    $rules = [['alpha'], ['required']];
+    $result = invalid($data, $rules);
+    $this->assertEquals(1, $result[1]);
+  }
 
-    $invalid  = invalid($data, $rules, $messages);    
-    $expected = array('name' => 'The name is required', 'street' => 'The street is required');
+  public function testInvalidRequired()
+  {
+    $rules = ['email' => ['required']];
+    $messages = ['email' => ''];
 
-    $this->assertEquals($expected, $invalid);
-        
+    $result = invalid(['email' => null], $rules, $messages);
+    $this->assertEquals($messages, $result);
+
+    $result = invalid(['name' => 'homer'], $rules, $messages);
+    $this->assertEquals($messages, $result);
+
+    $result = invalid(['email' => ''], $rules, $messages);
+    $this->assertEquals($messages, $result);
+
+    $result = invalid(['email' => []], $rules, $messages);
+    $this->assertEquals($messages, $result);
+
+    $result = invalid(['email' => '0'], $rules, $messages);
+    $this->assertEquals([], $result);
+
+    $result = invalid(['email' => 0], $rules, $messages);
+    $this->assertEquals([], $result);
+
+    $result = invalid(['email' => false], $rules, $messages);
+    $this->assertEquals([], $result);
+
+    $result = invalid(['email' => 'homer@simpson.com'], $rules, $messages);
+    $this->assertEquals([], $result);
+  }
+
+  public function testInvalidOptions()
+  {
+    $rules = [
+      'username' => ['min' => 6]
+    ];
+
+    $messages = ['username' => ''];
+
+    $result  = invalid(['username' => 'homer'], $rules, $messages);
+    $this->assertEquals($messages, $result);
+
+    $result  = invalid(['username' => 'homersimpson'], $rules, $messages);
+    $this->assertEquals([], $result);
+
+    $rules = [
+      'username' => ['between' => [3, 6]]
+    ];
+
+    $result  = invalid(['username' => 'ho'], $rules, $messages);
+    $this->assertEquals($messages, $result);
+
+    $result  = invalid(['username' => 'homersimpson'], $rules, $messages);
+    $this->assertEquals($messages, $result);
+
+    $result  = invalid(['username' => 'homer'], $rules, $messages);
+    $this->assertEquals([], $result);
   }
 }


### PR DESCRIPTION
I'm currently working on v3 of the [Uniform plugin](https://github.com/mzur/kirby-uniform). This version will be based on the [kirby-form](https://github.com/jevets/kirby-form) plugin which in turn makes use of the [invalid helper function](https://github.com/getkirby/toolkit/blob/fc3b1e886babbbc62b7a98f3deadbc639f1b9717/helpers.php#L312) to validate the form fields. To this end I'd like to propose some improvements to the invalid function. This PR consists of two idependent commits:

1. Improved 'required' validation. Now only `null`, `''`, `[]` or undefined variables are rejected by the required validation. Previously `'0'` was rejected, too.

2. Improved error messages. Now an array of error messages can be defined for each validation rule, too. Each item of the array corresponds to one validation method so the error messages can be more helpful. Example:

   ```php
   $rules = ['username' => ['required', 'alpha', 'min' => 4]];
   $messages = ['username' => [
      'The username is required.',
      'The username may only contain letters.',
      'The username must be at least 4 characters long.',
   ]];
   ```

I've also added a few tests to ensure backwards compatibility. Only the `array_unique` had to be removed which might result in duplicate error messages in old code.