### PR TITLE
Store Kirby Data as canonically composed (normalized) Unicode

### DIFF
--- a/lib/data.php
+++ b/lib/data.php
@@ -114,7 +114,7 @@ data::$adapters['kd'] = array(
       }
 
     }
-    return implode("\n\n----\n\n", $result);
+    return Normalizer::normalize( implode("\n\n----\n\n", $result), Normalizer::FORM_C );
 
   },
   'decode' => function($string) {


### PR DESCRIPTION
This would solve issues like https://forum.getkirby.com/t/unicode-normalization/1766

However, it requires php-intl...

This PR add normalization now only for Kirby data files, but maybe it would make sense for YAML and others, too?
