### PR TITLE
fix url::makeAbsolute() and url::short()

### DIFF
--- a/lib/url.php
+++ b/lib/url.php
@@ -250,33 +250,47 @@ class Url {
   }
 
   /**
-   * Convert a relative path into an absolute URL
+   * Convert a path into an absolute URL
    *
    * @param string $path
    * @param string $home
    * @return string
    */
   public static function makeAbsolute($path, $home = null) {
+    if(static::isAbsolute($path)) return $path;
+    // build the full url
+    $path = ltrim($path, '/');
+    $home = is_null($home) ? static::$home : $home;
+    if(empty($path)) return $home;
+    return $home == '/' ? '/' . $path : $home . '/' . $path;
+  }
+
+  /**
+   * Solves an URL relative to another URL
+   *
+   * @param string $base
+   * @param string $path
+   * @return string
+   */
+  public static function solveRelative($base, $path) {
 
     if(static::isAbsolute($path)) return $path;
 
-    $fragments = url::fragments($path);
+    $fragments = static::fragments($path);
 
     // If the path is not /absolute, take $home in account
     if(!str::startsWith($path, '/')) {
 
       $pathFragments = $fragments;
-      $homeFragments = url::fragments($home);
+      $baseFragments = static::fragments($base);
 
-      // If $home is not a folder, remove the last part
-      if(!str::endsWith($home, '/')) array_pop($homeFragments);
+      // If $base is not a folder, remove the last part
+      if(!str::endsWith($base, '/')) array_pop($baseFragments);
 
-      $fragments = $homeFragments;
+      $fragments = $baseFragments;
 
       foreach($pathFragments as $f) $fragments []= $f;
     }
-
-    $home = is_null($home) ? static::$home : $home;
 
     $filter = array(
       'hash' => '',
@@ -285,11 +299,7 @@ class Url {
       'fragments' => $fragments,
     );
 
-    $home = static::build($filter, $home);
-
-    if(empty($home)) $home = '/';
-
-    return $home;
+    return static::build($filter, $base);
 
   }
 

--- a/lib/url.php
+++ b/lib/url.php
@@ -260,10 +260,23 @@ class Url {
 
     if(static::isAbsolute($path)) return $path;
 
-    // build the full url
-    $path = ltrim($path, '/');
+    if(str::endsWith($home, '/')) {
+      $path = url::path($home) . '/' . $path;
+    }
+
     $home = is_null($home) ? static::$home : $home;
 
+    $filter = array(
+      'hash' => '',
+      'query' => '',
+      'params' => [],
+      'fragments' => []
+    );
+
+    $home = static::build($filter, $home);
+    $path = ltrim($path, '/');
+
+    if(empty($home)) $home = '/';
     if(empty($path)) return $home;
 
     return $home == '/' ? '/' . $path : $home . '/' . $path;

--- a/lib/url.php
+++ b/lib/url.php
@@ -362,7 +362,7 @@ class Url {
     if($base) $url = static::base($url);
 
     // replace all the nasty stuff from the url
-    $url = str_replace(array('http://', 'https://', 'ftp://', 'www.'), '', $url);
+    $url = str_replace(array('http://www.', 'https://www.', 'ftp://', 'http://', 'https://'), '', $url);
 
     // try to remove the last / after the url
     $url = rtrim($url, '/');

--- a/lib/url.php
+++ b/lib/url.php
@@ -18,11 +18,11 @@ class Url {
   public static $current = null;
 
   public static function scheme($url = null) {
-    if(is_null($url)) {      
+    if(is_null($url)) {
       if(
         (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) != 'off') ||
-        server::get('SERVER_PORT')            == '443' || 
-        server::get('HTTP_X_FORWARDED_PORT')  == '443' || 
+        server::get('SERVER_PORT')            == '443' ||
+        server::get('HTTP_X_FORWARDED_PORT')  == '443' ||
         server::get('HTTP_X_FORWARDED_PROTO') == 'https' ||
         server::get('HTTP_X_FORWARDED_PROTO') == 'https, http'
       ) {
@@ -90,7 +90,7 @@ class Url {
   /**
    * Returns the correct separator for parameters
    * depending on the operating system
-   * 
+   *
    * @return string
    */
   public static function paramSeparator() {
@@ -346,7 +346,7 @@ class Url {
       $port   = static::port($url);
       $scheme = static::scheme($url);
       $host   = static::host($url) . r(is_int($port), ':' . $port);
-      return r($scheme, $scheme . '://') . $host;      
+      return r($scheme, $scheme . '://') . $host;
     }
   }
 
@@ -399,9 +399,9 @@ class Url {
   }
 
   /**
-   * Returns the URL for document root no 
-   * matter what the path is. 
-   * 
+   * Returns the URL for document root no
+   * matter what the path is.
+   *
    * @return string
    */
   public static function index() {

--- a/lib/url.php
+++ b/lib/url.php
@@ -260,18 +260,15 @@ class Url {
 
     if(static::isAbsolute($path)) return $path;
 
-    $pathFragments = url::fragments($path);
+    $fragments = url::fragments($path);
 
-    // If the path starts with /, take only the path.
-    if(str::startsWith($path, '/')) {
+    // If the path is not /absolute, take $home in account
+    if(!str::startsWith($path, '/')) {
 
-      $fragments = $pathFragments;
-
-    } else {
-
+      $pathFragments = $fragments;
       $homeFragments = url::fragments($home);
 
-      // If home is not a folder, remove the last part
+      // If $home is not a folder, remove the last part
       if(!str::endsWith($home, '/')) array_pop($homeFragments);
 
       $fragments = $homeFragments;

--- a/lib/url.php
+++ b/lib/url.php
@@ -119,7 +119,7 @@ class Url {
   public static function fragments($url = null) {
     if(is_null($url)) $url = static::current();
     $path = static::path($url);
-    if(empty($path)) return null;
+    if(empty($path)) return array();
     $frag = array();
     foreach(explode('/', $path) as $part) {
       if(strpos($part, static::paramSeparator()) === false) $frag[] = $part;
@@ -260,8 +260,23 @@ class Url {
 
     if(static::isAbsolute($path)) return $path;
 
-    if(str::endsWith($home, '/')) {
-      $path = url::path($home) . '/' . $path;
+    $pathFragments = url::fragments($path);
+
+    // If the path starts with /, take only the path.
+    if(str::startsWith($path, '/')) {
+
+      $fragments = $pathFragments;
+
+    } else {
+
+      $homeFragments = url::fragments($home);
+
+      // If home is not a folder, remove the last part
+      if(!str::endsWith($home, '/')) array_pop($homeFragments);
+
+      $fragments = $homeFragments;
+
+      foreach($pathFragments as $f) $fragments []= $f;
     }
 
     $home = is_null($home) ? static::$home : $home;
@@ -270,16 +285,14 @@ class Url {
       'hash' => '',
       'query' => '',
       'params' => array(),
-      'fragments' => array()
+      'fragments' => $fragments,
     );
 
     $home = static::build($filter, $home);
-    $path = ltrim($path, '/');
 
     if(empty($home)) $home = '/';
-    if(empty($path)) return $home;
 
-    return $home == '/' ? '/' . $path : $home . '/' . $path;
+    return $home;
 
   }
 

--- a/lib/url.php
+++ b/lib/url.php
@@ -269,8 +269,8 @@ class Url {
     $filter = array(
       'hash' => '',
       'query' => '',
-      'params' => [],
-      'fragments' => []
+      'params' => array(),
+      'fragments' => array()
     );
 
     $home = static::build($filter, $home);

--- a/test/UrlTest.php
+++ b/test/UrlTest.php
@@ -99,4 +99,13 @@ class UrlTest extends PHPUnit_Framework_TestCase {
 
   }
 
+  public function testShort() {
+
+    $this->assertEquals(
+      url::short('http://no-www.org'),
+      'no-www.org'
+    );
+
+  }
+
 }

--- a/test/UrlTest.php
+++ b/test/UrlTest.php
@@ -11,5 +11,92 @@ class UrlTest extends PHPUnit_Framework_TestCase {
 
   }
 
+  public function testMakeAbsoluteWithDomain() {
+
+    $this->assertEquals(
+      url::makeAbsolute('/', 'http://getkirby.com'),
+      'http://getkirby.com'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('http://someothersite.com', 'http://getkirby.com'),
+      'http://someothersite.com'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('/a/root/path', 'http://getkirby.com'),
+      'http://getkirby.com/a/root/path'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('page-b', 'http://getkirby.com/page-a'),
+      'http://getkirby.com/page-b'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('child', 'http://getkirby.com/parent/'),
+      'http://getkirby.com/parent/child'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('page', 'http://getkirby.com/?query=weird'),
+      'http://getkirby.com/page'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('page', 'http://getkirby.com/#hash'),
+      'http://getkirby.com/page'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('page', 'http://getkirby.com/param:kirby'),
+      'http://getkirby.com/page'
+    );
+
+  }
+
+  public function testMakeAbsoluteWithoutDomain() {
+
+    $this->assertEquals(
+      url::makeAbsolute('/'),
+      '/'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('http://someothersite.com'),
+      'http://someothersite.com'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('/a/root/path'),
+      '/a/root/path'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('page-b'),
+      '/page-b'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('child', '/parent/'),
+      '/parent/child'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('page', '/?query=weird'),
+      '/page'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('page', '/#hash'),
+      '/page'
+    );
+
+    $this->assertEquals(
+      url::makeAbsolute('page', '/param:kirby'),
+      '/page'
+    );
+
+  }
 
 }

--- a/test/UrlTest.php
+++ b/test/UrlTest.php
@@ -39,6 +39,11 @@ class UrlTest extends PHPUnit_Framework_TestCase {
     );
 
     $this->assertEquals(
+      url::makeAbsolute('parent-b/subpage', 'https://getkirby.com/page/parent-a'),
+      'https://getkirby.com/page/parent-b/subpage'
+    );
+
+    $this->assertEquals(
       url::makeAbsolute('page', 'http://getkirby.com/?query=weird'),
       'http://getkirby.com/page'
     );

--- a/test/UrlTest.php
+++ b/test/UrlTest.php
@@ -11,95 +11,51 @@ class UrlTest extends PHPUnit_Framework_TestCase {
 
   }
 
-  public function testMakeAbsoluteWithDomain() {
+  public function testSolveRelative() {
 
     $this->assertEquals(
-      url::makeAbsolute('/', 'http://getkirby.com'),
+      url::solveRelative('http://getkirby.com', '/'),
       'http://getkirby.com'
     );
 
     $this->assertEquals(
-      url::makeAbsolute('http://someothersite.com', 'http://getkirby.com'),
+      url::solveRelative('http://getkirby.com', 'http://someothersite.com'),
       'http://someothersite.com'
     );
 
     $this->assertEquals(
-      url::makeAbsolute('/a/root/path', 'http://getkirby.com'),
+      url::solveRelative('http://getkirby.com', '/a/root/path'),
       'http://getkirby.com/a/root/path'
     );
 
     $this->assertEquals(
-      url::makeAbsolute('page-b', 'http://getkirby.com/page-a'),
+      url::solveRelative('http://getkirby.com/page-a', 'page-b'),
       'http://getkirby.com/page-b'
     );
 
     $this->assertEquals(
-      url::makeAbsolute('child', 'http://getkirby.com/parent/'),
+      url::solveRelative('http://getkirby.com/parent/', 'child'),
       'http://getkirby.com/parent/child'
     );
 
     $this->assertEquals(
-      url::makeAbsolute('parent-b/subpage', 'https://getkirby.com/page/parent-a'),
+      url::solveRelative('https://getkirby.com/page/parent-a', 'parent-b/subpage'),
       'https://getkirby.com/page/parent-b/subpage'
     );
 
     $this->assertEquals(
-      url::makeAbsolute('page', 'http://getkirby.com/?query=weird'),
+      url::solveRelative('http://getkirby.com/?query=weird', 'page'),
       'http://getkirby.com/page'
     );
 
     $this->assertEquals(
-      url::makeAbsolute('page', 'http://getkirby.com/#hash'),
+      url::solveRelative('http://getkirby.com/#hash', 'page'),
       'http://getkirby.com/page'
     );
 
     $this->assertEquals(
-      url::makeAbsolute('page', 'http://getkirby.com/param:kirby'),
+      url::solveRelative('http://getkirby.com/param:kirby', 'page'),
       'http://getkirby.com/page'
-    );
-
-  }
-
-  public function testMakeAbsoluteWithoutDomain() {
-
-    $this->assertEquals(
-      url::makeAbsolute('/'),
-      '/'
-    );
-
-    $this->assertEquals(
-      url::makeAbsolute('http://someothersite.com'),
-      'http://someothersite.com'
-    );
-
-    $this->assertEquals(
-      url::makeAbsolute('/a/root/path'),
-      '/a/root/path'
-    );
-
-    $this->assertEquals(
-      url::makeAbsolute('page-b'),
-      '/page-b'
-    );
-
-    $this->assertEquals(
-      url::makeAbsolute('child', '/parent/'),
-      '/parent/child'
-    );
-
-    $this->assertEquals(
-      url::makeAbsolute('page', '/?query=weird'),
-      '/page'
-    );
-
-    $this->assertEquals(
-      url::makeAbsolute('page', '/#hash'),
-      '/page'
-    );
-
-    $this->assertEquals(
-      url::makeAbsolute('page', '/param:kirby'),
-      '/page'
     );
 
   }

--- a/test/UrlTest.php
+++ b/test/UrlTest.php
@@ -3,7 +3,7 @@
 require_once('lib/bootstrap.php');
 
 class UrlTest extends PHPUnit_Framework_TestCase {
-  
+
   public function testHasQuery() {
 
     $this->assertTrue(url::hasQuery('http://getkirby.com/?search=some'));


### PR DESCRIPTION
Instead of filing issues I now try to fix issues :)

I had a bug that came down to relying on `url::makeAbsolute()` to fix a relative link. Turned out `url::makeAbsolute()` doesn't actually solve relative links, it just intelligently adds $path to $home.

So I made a few tests for urls it should solve in my opinion, and then I rewrote the function. It now passes all those tests, and also the tests on $home as `/`, because that seems to be the default.

I also noticed that `url::short()` would turn the url `http://no-www.org` into `no-org`, because of a `str_replace()` on `www.`, which isn't correct also, so I fixed that too.