### PR TITLE
Allow templating of language strings

### DIFF
--- a/lib/l.php
+++ b/lib/l.php
@@ -14,4 +14,13 @@
  */
 class L extends Silo {
   public static $data = array();
+
+  public static function get($key = null, $default = null) {
+    $value = parent::get($key, $default);
+    if (is_array($default)) {
+      return str::template($value, $default);
+    }
+
+    return $value;
+  }
 }

--- a/test/LTest.php
+++ b/test/LTest.php
@@ -3,7 +3,7 @@
 require_once('lib/bootstrap.php');
 
 class LTest extends PHPUnit_Framework_TestCase {
-  
+
   public function __construct() {
 
     l::set('testvar', 'testvalue');
@@ -11,11 +11,11 @@ class LTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testGet() {
-    
+
     $this->assertEquals('testvalue', l::get('testvar'));
     $this->assertEquals('defaultvalue', l::get('nonexistentvar', 'defaultvalue'));
 
-  }  
+  }
 
   public function testSet() {
 
@@ -33,6 +33,13 @@ class LTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('value1', l::get('var1'));
     $this->assertEquals('value2', l::get('var2'));
 
+  }
+
+  public function testTemplate() {
+    l::set('test', 'my {what} template');
+
+    $this->assertEquals('my {what} template', l::get('test', 'default'));
+    $this->assertEquals('my cool template', l::get('test', ['what' => 'cool']));
   }
 
 }


### PR DESCRIPTION
This makes things like these possible:

```php
l::set('terms', 'I accept the <a href="{link}">terms and conditions</a>.');

l::get('terms', ['link' => page('terms')->url()]);
// -> 'I accept the <a href="http://example.com/terms">terms and conditions</a>.'
```