### PR TITLE
Remove REMOTE_ADDR check from session fingerprint

### DIFF
--- a/lib/s.php
+++ b/lib/s.php
@@ -117,7 +117,7 @@ class S {
     } 
 
     if(!r::cli()) {
-      return sha1(Visitor::ua() . (ip2long($_SERVER['REMOTE_ADDR']) & ip2long('255.255.0.0')));      
+      return sha1(Visitor::ua());      
     } else {
       return '';
     }


### PR DESCRIPTION
This fixes the issue #215.

Alternative is to provide config parameter to have the old behavior, but I don't think the old behavior is worth to keep as it is quite wrong.