### PR TITLE
Improvements to header class (header::status, mostly)

### DIFF
--- a/lib/header.php
+++ b/lib/header.php
@@ -56,7 +56,7 @@ class Header {
    * @param string $mime
    * @param string $charset
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function contentType($mime, $charset = 'UTF-8', $send = true) {  
     if($found = f::extensionToMime($mime)) $mime = $found;
@@ -72,18 +72,22 @@ class Header {
    * @param string $mime
    * @param string $charset
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function type($mime, $charset = 'UTF-8', $send = true) {
     return static::contentType($mime, $charset, $send);
   }
 
   /**
-   * Sends a status header 
-   * 
-   * @param int $code The HTTP status code
+   * Sends a status header
+   *
+   * Checks $code against a list of known status codes. To bypass this check
+   * and send a custom status code and message, use a $code string formatted
+   * as 3 digits followed by a space and a message, e.g. '999 Custom Status'.
+   *
+   * @param int|string $code The HTTP status code
    * @param boolean $send If set to false the header will be returned instead
-   * @return mixed
+   * @return string|null
    */
   public static function status($code, $send = true) {
 
@@ -91,8 +95,8 @@ class Header {
     $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';
 
     // allow full control over code and message
-    if(is_string($code) && preg_match('/^\d{3} .+$/', $code) === 1) {
-      $message = substr($code, 4);
+    if(is_string($code) && preg_match('/^\d{3} \w.+$/', $code) === 1) {
+      $message = substr(rtrim($code), 4);
       $code = substr($code, 0, 3);
     } else {
       $code = !array_key_exists('_' . $code, $codes) ? 500 : $code;
@@ -111,7 +115,7 @@ class Header {
    * Sends a 200 header
    * 
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function success($send = true) {
     return static::status(200, $send);
@@ -121,7 +125,7 @@ class Header {
    * Sends a 201 header
    * 
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function created($send = true) {
     return static::status(201, $send);
@@ -131,7 +135,7 @@ class Header {
    * Sends a 202 header
    * 
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function accepted($send = true) {
     return static::status(202, $send);
@@ -141,7 +145,7 @@ class Header {
    * Sends a 400 header
    * 
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function error($send = true) {
     return static::status(400, $send);
@@ -151,7 +155,7 @@ class Header {
    * Sends a 403 header
    * 
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function forbidden($send = true) {
     return static::status(403, $send);
@@ -161,7 +165,7 @@ class Header {
    * Sends a 404 header
    * 
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function notfound($send = true) {
     return static::status(404, $send);
@@ -171,7 +175,7 @@ class Header {
    * Sends a 404 header
    * 
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function missing($send = true) {
     return static::status(404, $send);
@@ -181,7 +185,7 @@ class Header {
    * Sends a 410 header
    *
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function gone($send = true) {
     return static::status(410, $send);
@@ -191,7 +195,7 @@ class Header {
    * Sends a 500 header
    * 
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function panic($send = true) {
     return static::status(500, $send);
@@ -201,7 +205,7 @@ class Header {
    * Sends a 503 header
    * 
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function unavailable($send = true) {
     return static::status(503, $send);
@@ -211,7 +215,7 @@ class Header {
    * Sends a redirect header
    * 
    * @param boolean $send
-   * @return mixed
+   * @return string|null
    */
   public static function redirect($url, $code = 301, $send = true) {
 
@@ -219,7 +223,7 @@ class Header {
     $location = 'Location:' . $url;
 
     if(!$send) {
-      return $status . PHP_EOL . $location;
+      return $status . "\r\n" . $location;
     }
 
     header($status);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,4 +4,7 @@
       <directory>test</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <server name="SERVER_PROTOCOL" value="HTTP/1.1"/>
+  </php>
 </phpunit>

--- a/test/HeaderTest.php
+++ b/test/HeaderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Test the "header" class.
+ * All tests are performed by passing $send=false
+ */
+class HeaderTest extends PHPUnit_Framework_TestCase {
+
+  public function __construct() {
+    // incomplete list compared to header::$codes, mostly for
+    // testing header::success and other named methods
+    $this->statusHeaders = [
+      200 => 'HTTP/1.1 200 OK',
+      201 => 'HTTP/1.1 201 Created',
+      202 => 'HTTP/1.1 202 Accepted',
+      301 => 'HTTP/1.1 301 Moved Permanently',
+      302 => 'HTTP/1.1 302 Found',
+      400 => 'HTTP/1.1 400 Bad Request',
+      403 => 'HTTP/1.1 403 Forbidden',
+      404 => 'HTTP/1.1 404 Not Found',
+      410 => 'HTTP/1.1 410 Gone',
+      451 => 'HTTP/1.1 451 Unavailable For Legal Reasons',
+      500 => 'HTTP/1.1 500 Internal Server Error',
+      503 => 'HTTP/1.1 503 Service Unavailable'
+    ];
+  }
+
+  public function testNamedStatuses() {
+    $h = $this->statusHeaders;
+    $this->assertEquals($h[200], header::success(false), 'success status should be 200');
+    $this->assertEquals($h[201], header::created(false), 'success status should be 201');
+    $this->assertEquals($h[202], header::accepted(false), 'success status should be 200');
+    $this->assertEquals($h[400], header::error(false), 'error status should be 400');
+    $this->assertEquals($h[403], header::forbidden(false), 'forbidden status should be 403');
+    $this->assertEquals($h[404], header::notfound(false), 'notfound status should be 404');
+    $this->assertEquals($h[404], header::missing(false), 'missing status should be 404');
+    $this->assertEquals($h[410], header::gone(false), 'gone status should be 410');
+    $this->assertEquals($h[500], header::panic(false), 'panic status should be 500');
+    $this->assertEquals($h[503], header::unavailable(false), 'unavailable status should be 503');
+  }
+
+  public function testStatus_CodeOnly() {
+    $h = $this->statusHeaders;
+
+    // code only
+    $this->assertEquals($h[200], header::status(200, false), 'Accepts integer status code');
+    $this->assertEquals($h[200], header::status('200', false), 'Accepts string status code');
+    $this->assertEquals($h[451], header::status('451', false), 'Can send HTTP 451 code (RFC 7725)');
+    $this->assertEquals(header::status(500, false), header::status(null, false), 'Null code results in 500');
+    $this->assertEquals(header::status(500, false), header::status(999, false), 'Unknown code results in 500');
+
+    // with reason in code parameter
+    $this->assertEquals($h[200], header::status('200 OK', false), 'Can send "200 OK"');
+    $this->assertEquals('HTTP/1.1 999 Custom Header', header::status('999 Custom Header', false), 'Can send a well-formed custom status code and reason');
+    $this->assertEquals($h[500], header::status('9000 Over', false), 'Cannot send malformed status code and reason');
+  }
+
+  public function testRedirect() {
+    $h = $this->statusHeaders;
+    $this->assertEquals(
+      $h[301] . PHP_EOL . 'Location:/',
+      header::redirect('/', 301, false),
+      'Can send a 301 redirect'
+    );
+    $this->assertEquals(
+      $h[302] . PHP_EOL . 'Location:/',
+      header::redirect('/', 302, false),
+      'Can send a 302 redirect'
+    );
+  }
+
+  public function testContentType() {
+    $this->assertEquals(
+      'Content-type: video/webm',
+      header::contentType('webm', '', false),
+      'Can send Content-type header with no encoding'
+    );
+    $this->assertEquals(
+      'Content-type: application/json; charset=ISO-8859-1',
+      header::contentType('json', 'ISO-8859-1', false),
+      'Can send Content-type header with custom encoding'
+    );
+  }
+
+}

--- a/test/HeaderTest.php
+++ b/test/HeaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once('lib/bootstrap.php');
+
 /**
  * Test the "header" class.
  * All tests are performed by passing $send=false
@@ -28,8 +30,8 @@ class HeaderTest extends PHPUnit_Framework_TestCase {
   public function testNamedStatuses() {
     $h = $this->statusHeaders;
     $this->assertEquals($h[200], header::success(false), 'success status should be 200');
-    $this->assertEquals($h[201], header::created(false), 'success status should be 201');
-    $this->assertEquals($h[202], header::accepted(false), 'success status should be 200');
+    $this->assertEquals($h[201], header::created(false), 'created status should be 201');
+    $this->assertEquals($h[202], header::accepted(false), 'accepted status should be 202');
     $this->assertEquals($h[400], header::error(false), 'error status should be 400');
     $this->assertEquals($h[403], header::forbidden(false), 'forbidden status should be 403');
     $this->assertEquals($h[404], header::notfound(false), 'notfound status should be 404');
@@ -43,28 +45,50 @@ class HeaderTest extends PHPUnit_Framework_TestCase {
     $h = $this->statusHeaders;
 
     // code only
-    $this->assertEquals($h[200], header::status(200, false), 'Accepts integer status code');
-    $this->assertEquals($h[200], header::status('200', false), 'Accepts string status code');
-    $this->assertEquals($h[451], header::status('451', false), 'Can send HTTP 451 code (RFC 7725)');
-    $this->assertEquals(header::status(500, false), header::status(null, false), 'Null code results in 500');
-    $this->assertEquals(header::status(500, false), header::status(999, false), 'Unknown code results in 500');
+    $this->assertEquals(
+      $h[200], header::status(200, false),
+      'Accepts integer status code'
+    );
+    $this->assertEquals(
+      $h[200], header::status('200', false),
+      'Accepts string status code'
+    );
+    $this->assertEquals(
+      $h[451], header::status('451', false),
+      'Can send HTTP 451 code (RFC 7725)'
+    );
+    $this->assertEquals(
+      $h[500], header::status(null, false),
+      'Null code results in 500'
+    );
+    $this->assertEquals(
+      header::status(500, false), header::status(999, false),
+      'Unknown code results in 500'
+    );
 
     // with reason in code parameter
-    $this->assertEquals($h[200], header::status('200 OK', false), 'Can send "200 OK"');
-    $this->assertEquals('HTTP/1.1 999 Custom Header', header::status('999 Custom Header', false), 'Can send a well-formed custom status code and reason');
-    $this->assertEquals($h[500], header::status('9000 Over', false), 'Cannot send malformed status code and reason');
+    $this->assertEquals(
+      $h[200], header::status('200 OK', false),
+      'Can send "200 OK"'
+    );
+    $this->assertEquals(
+      'HTTP/1.1 999 Custom Header', header::status('999 Custom Header', false),
+      'Can send a well-formed custom status code and reason'
+    );
+    $this->assertEquals(
+      $h[500], header::status("999 This is\nNOT OKAY", false),
+      'Newlines inside of reason results in a 500 code'
+    );
   }
 
   public function testRedirect() {
     $h = $this->statusHeaders;
     $this->assertEquals(
-      $h[301] . PHP_EOL . 'Location:/',
-      header::redirect('/', 301, false),
+      $h[301] . "\r\nLocation:/x", header::redirect('/x', 301, false),
       'Can send a 301 redirect'
     );
     $this->assertEquals(
-      $h[302] . PHP_EOL . 'Location:/',
-      header::redirect('/', 302, false),
+      $h[302] . "\r\nLocation:/x", header::redirect('/x', 302, false),
       'Can send a 302 redirect'
     );
   }
@@ -78,7 +102,7 @@ class HeaderTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals(
       'Content-type: application/json; charset=ISO-8859-1',
       header::contentType('json', 'ISO-8859-1', false),
-      'Can send Content-type header with custom encoding'
+      'Can send Content-type header with custom charset'
     );
   }
 


### PR DESCRIPTION
As a fix for https://github.com/getkirby/toolkit/issues/212, I tried my hand at making a few improvements to the `header` class.

Changes are:

0. Wrote a bunch of tests. Yay, tests!

1. Add 7 entries to `header::$codes`. Main ones are:
    - `410 Gone` for deleted/archived content (more info: https://indieweb.org/deleted).
    - `451 Unavailable For Legal Reasons`, a special case of 404/410, poetically named after Fahrenheit 451 ([RFC 7725](https://tools.ietf.org/html/rfc7725)); admittedly it’s still a Proposed Standard.
    - `504 Gateway Time-out`, can be useful if you’re doing a server-side request on some API which times out.

2. Added a `header::gone()` shortcut for `410 Gone` statuses.

3. `header::status()` default for an unknown code is now a 500 error, and not a 400 error. No need to tell a browser that a request was badly formed when it's the server-side code which is at fault. ;) (I’d suggest `header::error()` returning a 400 is not a great choice, and the 500-returning shortcut being `header::panic()` is needlessly alarming, but that ship has sailed.)

4. Added the possibility to treat the `$code` in `header::status()` as a custom status code plus Reason Phrase. E.g. `header::status('999 Somewhere over the rainbow');` would work. The rationale is to allow for future statuses or existing ones that were not included in the toolkit. Note that the Reason Phrase in HTTP is free-form, it’s made for humans and not machines, and the spec mentions use cases such as localizing that phrase (though I’m pretty sure it’s limited to ISO-8859-1, and MIME encoding works for headers but not for the status header).
    This feature uses a regex check that looks for `[3 digits][space][letter][more stuff but not a new line]`, so it won’t pick up things like untrimmed strings with just a number, e.g. `'200 '` will continue *not* working. ^^

5. In `header::redirect`, when returning a string, I changed the line separator to `"\r\n"` (instead of `PHP_EOL`) because that’s the specified line separator for HTTP headers.

I’m allowing edits from maintainers, so if someone wants to dive in and change things, maybe only keep some of the changes, be my guest. :)

For instance I’m not 100 percent sure that the `header::status('### Reason')` syntax is needed, since one can just use `header('HTTP/1.1 ### Reason')` directly. But on the other hand it might be useful for use with other code which uses the header class, e.g. `new Response($content, 'html', '### Reason');`.