### PR TITLE
add parse_str() to str::parse()

### DIFF
--- a/lib/str.php
+++ b/lib/str.php
@@ -188,7 +188,6 @@ class Str {
    * - url
    * - query
    * - php
-   * - form
    *
    * <code>
    *
@@ -224,7 +223,7 @@ class Str {
         return (array)@parse_url($string);
       case 'php':
         return @unserialize($string);
-      case 'form':
+      case 'query':
         @parse_str($string, $result);
         return $result;
       default:

--- a/lib/str.php
+++ b/lib/str.php
@@ -188,6 +188,7 @@ class Str {
    * - url
    * - query
    * - php
+   * - form
    *
    * <code>
    *
@@ -223,6 +224,9 @@ class Str {
         return (array)@parse_url($string);
       case 'php':
         return @unserialize($string);
+      case 'form':
+        @parse_str($string, $result);
+        return $result;
       default:
         return $string;
     }

--- a/lib/str.php
+++ b/lib/str.php
@@ -92,12 +92,12 @@ class Str {
 
   /**
    * Default options for string methods
-   * 
+   *
    * @var array
    */
   public static $defaults = array(
     'slug' => array(
-      'separator' => '-', 
+      'separator' => '-',
       'allowed'   => 'a-z0-9'
     )
   );
@@ -241,11 +241,11 @@ class Str {
     for($i = 0; $i < static::length($string); $i++) {
       $char = static::substr($string, $i, 1);
       if(MB) {
-        list(, $code) = unpack('N', mb_convert_encoding($char, 'UCS-4BE', 'UTF-8'));        
+        list(, $code) = unpack('N', mb_convert_encoding($char, 'UCS-4BE', 'UTF-8'));
       } else {
         $code = ord($char);
       }
-      
+
       $encoded .= rand(1, 2) == 1 ? '&#' . $code . ';' : '&#x' . dechex($code) . ';';
     }
     return $encoded;
@@ -314,7 +314,7 @@ class Str {
 
   /**
    * Checks if the given string is a URL
-   * 
+   *
    * @param string $string
    * @return boolean
    */
@@ -443,7 +443,7 @@ class Str {
 
   /**
    * Generates a random string that may be used for cryptographic purposes
-   * 
+   *
    * WARNING (PHP < 7.0): This function does *not* produce secure random
    * strings and falls back to str::quickRandom with PHP < 7.0!
    *
@@ -514,7 +514,7 @@ class Str {
 
     // replace spaces with simple dashes
     $string = preg_replace('![^' . $allowed . ']!i', $separator, $string);
-    
+
     if(strlen($separator) > 0) {
       // remove double separators
       $string = preg_replace('![' . preg_quote($separator) . ']{2,}!', $separator, $string);
@@ -741,7 +741,7 @@ class Str {
 
   /**
    * Returns the beginning of a string before the given character
-   * 
+   *
    * @param string $string
    * @param string $char
    * @return string
@@ -753,7 +753,7 @@ class Str {
 
   /**
    * Returns the beginning of a string until the given character
-   * 
+   *
    * @param string $string
    * @param string $char
    * @return string
@@ -765,7 +765,7 @@ class Str {
 
   /**
    * Returns the rest of the string after the given character
-   * 
+   *
    * @param string $string
    * @param string $char
    * @return string
@@ -777,7 +777,7 @@ class Str {
 
   /**
    * Returns the rest of the string starting from the given character
-   * 
+   *
    * @param string $string
    * @param string $char
    * @return string

--- a/test/StrTest.php
+++ b/test/StrTest.php
@@ -34,7 +34,7 @@ class StrTest extends PHPUnit_Framework_TestCase {
 
     $this->assertEquals(str::parse('{"test":{"cool":"nice"},"super":"genious"}'), $array);
 
-    $this->assertEquals(str::parse('test[cool]=nice&super=genious', 'form'), $array);
+    $this->assertEquals(str::parse('test[cool]=nice&super=genious', 'query'), $array);
   }
 
   public function testEncode() {

--- a/test/StrTest.php
+++ b/test/StrTest.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once('lib/bootstrap.php');
- 
+
 class StrTest extends PHPUnit_Framework_TestCase {
 
   protected $sample = 'Super Äwesøme String';
@@ -35,20 +35,20 @@ class StrTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testLink() {
-    
+
     // without text
     $this->assertEquals('<a href="http://getkirby.com">http://getkirby.com</a>', str::link('http://getkirby.com'));
-    
+
     // with text
     $this->assertEquals('<a href="http://getkirby.com">Kirby</a>', str::link('http://getkirby.com', 'Kirby'));
 
   }
 
   public function testShort() {
-    
+
     // too long
     $this->assertEquals('Super…', str::short($this->sample, 5));
-    
+
     // not too long
     $this->assertEquals($this->sample, str::short($this->sample, 100));
 
@@ -85,7 +85,7 @@ class StrTest extends PHPUnit_Framework_TestCase {
   public function testUpper() {
     $this->assertEquals('SUPER ÄWESØME STRING', str::upper($this->sample));
   }
-  
+
   public function testLength() {
     $this->assertEquals(20, str::length($this->sample));
   }
@@ -98,7 +98,7 @@ class StrTest extends PHPUnit_Framework_TestCase {
     // don't ignore upper/lowercase
     $this->assertFalse(str::contains($this->sample, 'äwesøme', false));
 
-    // check for something which isn't there    
+    // check for something which isn't there
     $this->assertFalse(str::contains($this->sample, 'Peter'));
 
   }
@@ -201,12 +201,12 @@ class StrTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($array, str::split('design, super,, fun, great,,, nice/super'));
 
   }
-  
+
   public function testUcwords() {
 
     $string = str::lower($this->sample);
     $this->assertEquals($this->sample, str::ucwords($string));
-    
+
   }
 
   public function testUcfirst() {
@@ -214,19 +214,19 @@ class StrTest extends PHPUnit_Framework_TestCase {
     $string = str::lower($this->sample);
 
     $this->assertEquals('Super äwesøme string', str::ucfirst($string));
-    
+
   }
 
   public function testUtf8() {
 
     $this->assertEquals($this->sample, str::utf8($this->sample));
-    
+
   }
 
   public function testStripslashes() {
     // no test yet
   }
-     
+
 }
 
 ?>

--- a/test/StrTest.php
+++ b/test/StrTest.php
@@ -23,7 +23,18 @@ class StrTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testParse() {
-    // no test yet
+    $array = array(
+      'test' => array(
+        'cool' => 'nice'
+      ),
+      'super' => 'genious'
+    );
+
+    $this->assertEquals(str::parse('<xml><test><cool>nice</cool></test><super>genious</super></xml>', 'xml'), $array);
+
+    $this->assertEquals(str::parse('{"test":{"cool":"nice"},"super":"genious"}'), $array);
+
+    $this->assertEquals(str::parse('test[cool]=nice&super=genious', 'form'), $array);
   }
 
   public function testEncode() {


### PR DESCRIPTION
I was expecting parse_str() to be a mode of str::parse(), but it was not. I think it’s a good addition, especially because parse_str() by default throws stuff in the global scope, so you need to pass in a variable by reference and all that stuff.

Also added tests!

From [php.net](http://php.net/manual/en/function.parse-str.php):
```php
$str = "first=value&arr[]=foo+bar&arr[]=baz";

// Recommended
parse_str($str, $output);
echo $output['first'];  // value
echo $output['arr'][0]; // foo bar
echo $output['arr'][1]; // baz

// DISCOURAGED
parse_str($str);
echo $first;  // value
echo $arr[0]; // foo bar
echo $arr[1]; // baz
```
And now:
```php
$a = str::parse($str, 'form');
```