### PR TITLE
Include all options in settingsIdentifier

### DIFF
--- a/lib/thumb.php
+++ b/lib/thumb.php
@@ -165,16 +165,12 @@ class Thumb extends Obj {
   public function settingsIdentifier() {
 
     // build the settings string
-    return implode('-', array(
-      ($this->options['width'])   ? $this->options['width']   : 0,
-      ($this->options['height'])  ? $this->options['height']  : 0,
-      ($this->options['upscale']) ? $this->options['upscale'] : 0,
-      ($this->options['crop'])    ? $this->options['crop']    : 0,
-       $this->options['blur'],
-       $this->options['grayscale'],
-       $this->options['quality']
-    ));
+    $keys = $this->options;
 
+    // skip keys that can't be converted to strings
+    unset($keys['destination']);
+ 
+    return implode('-', array_keys($keys)) . implode('-', $keys);
   }
 
   /**


### PR DESCRIPTION
## Changes

Change `thumb->settingsIdentifier()` to include all options and all option values instead of only a specific whitelist of values.

I had to excluding the `destination` option as it type can't be converted to a string. Might be a nicer way to check that, but wasn't sure it'd be necessary.

## Reasoning

Background: I have a custom thumb driver, which includes some extra advanced options for ImageMagick. E.g. an option to add the "flatten" command, to create a still from a GIF. I also have my config set to include the `{hash}` in the filename:

    c::set('thumbs.filename', '{safeName}-{hash}-{width}x{height}.{extension}');

Given that scenario, if I create a "flattened" and "unflattened" thumbnail at the same size, they'll both get the same filename (including hash). Seems like a logical way to insure the filenames never collide is to include all the options.