### PR TITLE
Combine multiple HTTP header fields in remote, most BC solution.

### DIFF
--- a/lib/remote.php
+++ b/lib/remote.php
@@ -155,7 +155,11 @@ class Remote {
 
     if(!empty($parts[0]) && !empty($parts[1])) {
       $key = array_shift($parts);
-      $this->headers[$key] = implode(':', $parts);
+      if(!empty($this->headers[$key])) {
+      	$this->headers[$key] .= ', ' . implode(':', $parts);
+      } else {
+      	$this->headers[$key] = implode(':', $parts);
+      }
     }
 
     return strlen($header);


### PR DESCRIPTION
This fixes #234. At least a little.

Per [RFC 2616, section 4.2](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) headers that share the same field-name can be combined by appending subsequent field-values as comma separated values.

There are a lot of nuances being skipped in the Kirby Toolkit implementation. E.g. header field names are case-insensitive so `Link` and `linK` are the same. The current implementation doesn’t do anything about this and neither does this fix.

A better fix might have been to create a sub-array with all the case-normalised headers that came in under a field name. That would make sure weird header formats like Set-Cookie [don’t horribly break comma separated values](https://stackoverflow.com/a/6375214). The reason I didn’t do this is because it would change the API in a BC-breaking way.

All this fix is doing is naïvely making sure no data is discarded. The array structures are left as they are, getting around any API changes and BC breaks.