### PR TITLE
Return duplicade HTTP header fields in remote as array.

### DIFF
--- a/lib/remote.php
+++ b/lib/remote.php
@@ -156,7 +156,7 @@ class Remote {
     if(!empty($parts[0]) && !empty($parts[1])) {
       $key = array_shift($parts);
 
-      if (empty($this->headers[$key])) {
+      if (!isset($this->headers[$key])) {
         $this->headers[$key] = implode(':', $parts);
       } elseif (is_array($this->headers[$key])) {
           $this->headers[$key][] = implode(':', $parts);

--- a/lib/remote.php
+++ b/lib/remote.php
@@ -155,7 +155,15 @@ class Remote {
 
     if(!empty($parts[0]) && !empty($parts[1])) {
       $key = array_shift($parts);
-      $this->headers[$key] = implode(':', $parts);
+
+      if (empty($this->headers[$key])) {
+        $this->headers[$key] = implode(':', $parts);
+      } elseif (is_array($this->headers[$key])) {
+          $this->headers[$key][] = implode(':', $parts);
+      } else {
+        $this->headers[$key] = [$this->headers[$key], implode(':', $parts)]; 
+      }
+
     }
 
     return strlen($header);


### PR DESCRIPTION
Fixes #234 per discussion in #235. No header field name normalisation,
but no more loss of data.