### PR TITLE
Add 'file', 'filesize', 'mime' and 'image' validators

### DIFF
--- a/lib/v.php
+++ b/lib/v.php
@@ -133,5 +133,40 @@ v::$validators = array(
     // In search for the perfect regular expression: https://mathiasbynens.be/demo/url-regex
     $regex = '_^(?:(?:https?|ftp)://)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)*(?:\.(?:[a-z\x{00a1}-\x{ffff}]{2,})))(?::\d{2,5})?(?:/[^\s]*)?$_iu';
     return preg_match($regex, $value) !== 0;
-  }
+  },
+  'file' => function ($value) {
+    return is_array($value) && array_key_exists('tmp_name', $value) && is_uploaded_file($value['tmp_name']);
+  },
+  'filesize' => function ($value, $size) {
+    // $size is in kb and $value['size'] is in byte, so multiply by 1000
+    return is_array($value) && array_key_exists('size', $value) && $value['size'] <= $size * 1000;
+  },
+  'mime' => function ($value, $allowed) {
+    if (is_string($value)) {
+      $name = $value;
+    } elseif (is_array($value) && array_key_exists('tmp_name', $value)) {
+      // This is for uploaded files from $_FILES
+      $name = $value['tmp_name'];
+    }
+
+    if (isset($name)) {
+      return in_array(f::mime($name), $allowed);
+    }
+
+    return false;
+  },
+  'image' => function ($value) {
+    if (is_string($value)) {
+      $name = $value;
+    } elseif (is_array($value) && array_key_exists('tmp_name', $value)) {
+      // This is for uploaded files from $_FILES
+      $name = $value['tmp_name'];
+    }
+
+    if (isset($name)) {
+      return f::type($name) === 'image';
+    }
+
+    return false;
+  },
 );

--- a/test/VTest.php
+++ b/test/VTest.php
@@ -3,7 +3,7 @@
 require_once('lib/bootstrap.php');
 
 class VTest extends PHPUnit_Framework_TestCase {
-  
+
   public function testMatch() {
 
     $value = 'super-09';
@@ -143,6 +143,33 @@ class VTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue(v::size('super', 5));
     $this->assertTrue(v::size('1234', 1234));
     $this->assertTrue(v::size(range(0,9), 10));
+  }
+
+  public function testFilesize() {
+    $this->assertTrue(v::filesize(['size' => 9000], 9));
+    $this->assertFalse(v::filesize(['size' => 9000], 8));
+    $this->assertFalse(v::filesize([], 8));
+    $this->assertFalse(v::filesize('asdf', 8));
+  }
+
+  public function testMime() {
+    $path = sys_get_temp_dir().'/kirby_test_mime';
+    file_put_contents($path, 'sometext');
+    $this->assertTrue(v::mime(['tmp_name' => $path], ['text/plain']));
+    $this->assertTrue(v::mime($path, ['text/plain']));
+    $this->assertFalse(v::mime($path, ['image/png']));
+    unlink($path);
+  }
+
+  public function testImage()
+  {
+    $path = sys_get_temp_dir().'/kirby_test_image';
+    file_put_contents($path, 'sometext');
+    $this->assertFalse(v::image($path));
+    // This is a GIF: http://probablyprogramming.com/2009/03/15/the-tiniest-gif-ever
+    file_put_contents($path, base64_decode('R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='));
+    $this->assertTrue(v::image($path));
+    unlink($path);
   }
 
 }


### PR DESCRIPTION
I've implemented these for the new Uniform upload action ( mzur/kirby-uniform#113 ). This will allow validation of file uploads with Uniform or kirby-form that looks like this:

```php
$form = new Form([
    'filefield' => [
        'rules' => [
            'required',
            'file',
            'mime' => ['application/pdf'],
            'filesize' => 5000,
        ],
        'message' => [
            'Please choose a file.',
            'Please choose a file.',
            'Please choose a PDF.',
            'Please choose a file that is smaller than 5 MB.',
        ],
    ],
]);
```