### PR TITLE
Use own getimagesize() function

### DIFF
--- a/lib/media.php
+++ b/lib/media.php
@@ -428,7 +428,7 @@ class Media {
     if(isset($this->cache['dimensions'])) return $this->cache['dimensions'];
 
     if($this->type() == 'image') {
-      $size   = (array)getimagesize($this->root);
+      $size   = $this->getimagesize();
       $width  = a::get($size, 0, 0);
       $height = a::get($size, 1, 0);
     } else {

--- a/lib/media.php
+++ b/lib/media.php
@@ -428,7 +428,7 @@ class Media {
     if(isset($this->cache['dimensions'])) return $this->cache['dimensions'];
 
     if($this->type() == 'image') {
-      $size   = $this->getimagesize();
+      $size   = $this->imagesize();
       $width  = a::get($size, 0, 0);
       $height = a::get($size, 1, 0);
     } else {


### PR DESCRIPTION
I’m currently working on a replacement for `getimagesize` that is faster. When I started looking around in de code I came accross `$size   = (array)getimagesize($this->root);` while the `Media` class has its own `getimagesize` function. It’s handier if that one is called instead.