### PR TITLE
Fixed recursive folder creation

### DIFF
--- a/lib/folder.php
+++ b/lib/folder.php
@@ -258,12 +258,15 @@ class Folder {
    */
   public function copy($to) {
 
+    // Get content before destination directory is made
+    $content = $this->content();
+
     // Make destination directory
     $copy = new static($to);
     if(!$copy->make()) return false;
 
     // Loop through all subfiles and folders
-    foreach($this->content() as $item) {
+    foreach($content as $item) {
       if(is_a($item, 'Folder')) {
         $dest = $to . DS . $item->name();
       } else {

--- a/lib/folder.php
+++ b/lib/folder.php
@@ -259,6 +259,7 @@ class Folder {
   public function copy($to) {
 
     // Get content before destination directory is made
+    // (prevents endless recursion)
     $content = $this->content();
 
     // Make destination directory


### PR DESCRIPTION
When you try to copy a folder inside itself you get a recurisve folder creation because the content of the folder is scanned after the creation of the destination folder.

https://github.com/lukaskleinschmidt/kirby-sortable/issues/38