### PR TITLE
Make widont regex multibyte-safe (UTF-8).

### DIFF
--- a/lib/str.php
+++ b/lib/str.php
@@ -376,7 +376,7 @@ class Str {
    * @return string
    */
   public static function widont($string = '') {
-    return preg_replace_callback('|([^\s])\s+([^\s]+)\s*$|', function($matches) {
+    return preg_replace_callback('|([^\s])\s+([^\s]+)\s*$|u', function($matches) {
       if(str::contains($matches[2], '-')) {
         return $matches[1] . ' ' . str_replace('-', '&#8209;', $matches[2]);
       } else {


### PR DESCRIPTION
I saw an issue with my local PHP installation where using the `widont` function in a plugin would fail if the string contained the name `František Štorm`, which obviously has characters outside of the ASCII range.

Appending a `u` to the regex fixed it for me.

See also https://stackoverflow.com/a/31232938 and https://stackoverflow.com/a/1766767.