### PR TITLE
Fix typing of map parameter

### DIFF
--- a/lib/collection.php
+++ b/lib/collection.php
@@ -408,7 +408,7 @@ class Collection extends I implements Countable {
   /**
    * Map a function to each item in the collection
    *
-   * @param function $callback
+   * @param callable $callback
    * @return Collection
    */
   public function map($callback) {

--- a/lib/collection.php
+++ b/lib/collection.php
@@ -238,7 +238,7 @@ class Collection extends I implements Countable {
   /**
    * Filter the elements in the array by a callback function
    *
-   * @param  func $callback the callback function
+   * @param  callable $callback the callback function
    * @return Collection
    */
   public function filter($callback) {


### PR DESCRIPTION
`array_map` takes a parameter of type `callable`. The PHPdoc comment should also use this type, so IDEs don't warn users when using anonymous functions which are fine here.