### PR TITLE
Possible fix for Windows file TYPE checking.

### DIFF
--- a/lib/f.php
+++ b/lib/f.php
@@ -690,7 +690,7 @@ class F {
       $extension = pathinfo($file, PATHINFO_EXTENSION);
     }
 
-    if(empty($extension)) {
+    if(empty($extension) || $extension == 'tmp') {
       // detect the mime type first to get the most reliable extension
       $mime      = static::mime($file);
       $extension = static::mimeToExtension($mime);


### PR DESCRIPTION
I noticed avatars weren't uploading on a Windows web server due to the "image" type not being returned despite MIME checking returning "image/***" correctly. I narrowed it down to Windows returning "*.tmp" as the filename for the upload instead of the actual filename.

This is maybe a possible solution. Allowing MIME type checking on "tmp" files then allows Windows web servers to correctly categorise the file. I don't believe this lowers security at all because the actual MIME type check has to be performed.