### PR TITLE
Prevent conflict with Composer `dump` method

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -103,14 +103,16 @@ function ecco($condition, $value, $alternative = null) {
  * @param boolean $echo
  * @return string
  */
-function dump($variable, $echo = true) {
-  if(r::cli()) {
-    $output = print_r($variable, true) . PHP_EOL;
-  } else {
-    $output = '<pre>' . print_r($variable, true) . '</pre>';
+if (!function_exists('dump')) {
+  function dump($variable, $echo = true) {
+    if(r::cli()) {
+      $output = print_r($variable, true) . PHP_EOL;
+    } else {
+      $output = '<pre>' . print_r($variable, true) . '</pre>';
+    }
+    if($echo === true) echo $output;
+    return $output;
   }
-  if($echo === true) echo $output;
-  return $output;
 }
 
 /**


### PR DESCRIPTION
When `Valet` has been installed, running `kirby update` causes the following error:

> PHP Fatal error:  Cannot redeclare dump() (previously declared in /Users/xx/.composer/vendor/symfony/var-dumper/Resources/functions/dump.php:18) in /Users/xx/website/kirby/vendor/getkirby/toolkit/helpers.php on line 114

This patch prevents `dump` from being redeclared.


Forum discussion: https://forum.getkirby.com/t/php-fatal-error-cannot-redeclare-dump/9774/2