### PR TITLE
Fixed sql binding not being unique on Windows

### DIFF
--- a/lib/sql.php
+++ b/lib/sql.php
@@ -106,7 +106,7 @@ sql::registerMethod('generateBindingName', function($sql, $label) {
   // make sure that the binding name is valid to prevent injections
   if(!preg_match('/^[a-z0-9]+$/', $label)) $label = 'invalid';
   
-  return ':' . $label . '_' . uniqid();
+  return str_replace('.', '', uniqid(':' . $label . '_', true));
 });
 
 /**


### PR DESCRIPTION
uniqid() on Windows has a low chance of being unique, which causes the binding ids to clash and totally destroy the SQL queries.
Allowing uniqid() to generate more entropy makes it unique again, but introduces a dot, which then fails with the associative key lookup.

### References

- [PHP documentation](http://php.net/manual/en/function.uniqid.php)
- Similar fix was applied for example in [Typo3](https://review.typo3.org/#/c/43244/3/typo3/sysext/core/Classes/Utility/StringUtility.php)
- Informative [SO answer](https://stackoverflow.com/a/4070142/1034248)